### PR TITLE
feat: Post가 BlogId와 PostId를 복합키로 갖도록 설정

### DIFF
--- a/src/main/java/com/mallang/comment/application/AuthCommentService.java
+++ b/src/main/java/com/mallang/comment/application/AuthCommentService.java
@@ -26,9 +26,9 @@ public class AuthCommentService {
     private final CommentDeleteService commentDeleteService;
 
     public Long write(WriteAuthCommentCommand command) {
-        Post post = postRepository.getById(command.postId());
+        Post post = postRepository.getByIdAndBlogName(command.postId(), command.blogName());
         Member writer = memberRepository.getById(command.memberId());
-        Comment parent = commentRepository.getParentByIdAndPostId(command.parentCommentId(), command.postId());
+        Comment parent = commentRepository.getParentByIdAndPost(command.parentCommentId(), post);
         AuthComment comment = command.toComment(post, writer, parent);
         comment.write(command.postPassword());
         return commentRepository.save(comment).getId();

--- a/src/main/java/com/mallang/comment/application/UnAuthCommentService.java
+++ b/src/main/java/com/mallang/comment/application/UnAuthCommentService.java
@@ -26,8 +26,8 @@ public class UnAuthCommentService {
     private final CommentDeleteService commentDeleteService;
 
     public Long write(WriteUnAuthCommentCommand command) {
-        Post post = postRepository.getById(command.postId());
-        Comment parent = commentRepository.getParentByIdAndPostId(command.parentCommentId(), command.postId());
+        Post post = postRepository.getByIdAndBlogName(command.postId(), command.blogName());
+        Comment parent = commentRepository.getParentByIdAndPost(command.parentCommentId(), post);
         UnAuthComment comment = command.toCommand(post, parent);
         comment.write(command.postPassword());
         return commentRepository.save(comment).getId();

--- a/src/main/java/com/mallang/comment/application/command/WriteAuthCommentCommand.java
+++ b/src/main/java/com/mallang/comment/application/command/WriteAuthCommentCommand.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 @Builder
 public record WriteAuthCommentCommand(
         Long postId,
+        String blogName,
         String content,
         boolean secret,
         Long memberId,

--- a/src/main/java/com/mallang/comment/application/command/WriteUnAuthCommentCommand.java
+++ b/src/main/java/com/mallang/comment/application/command/WriteUnAuthCommentCommand.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 @Builder
 public record WriteUnAuthCommentCommand(
         Long postId,
+        String blogName,
         String content,
         String nickname,
         String password,

--- a/src/main/java/com/mallang/comment/domain/Comment.java
+++ b/src/main/java/com/mallang/comment/domain/Comment.java
@@ -16,6 +16,7 @@ import jakarta.persistence.ForeignKey;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
@@ -35,7 +36,10 @@ public abstract class Comment extends CommonDomainModel {
     protected String content;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "post_id", nullable = false)
+    @JoinColumns({
+            @JoinColumn(name = "post_id", referencedColumnName = "post_id"),
+            @JoinColumn(name = "blog_id", referencedColumnName = "blog_id"),
+    })
     protected Post post;
 
     protected boolean deleted;

--- a/src/main/java/com/mallang/comment/domain/CommentRepository.java
+++ b/src/main/java/com/mallang/comment/domain/CommentRepository.java
@@ -1,12 +1,15 @@
 package com.mallang.comment.domain;
 
 import com.mallang.comment.exception.NotFoundCommentException;
+import com.mallang.post.domain.Post;
+import com.mallang.post.domain.PostId;
 import jakarta.annotation.Nullable;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
@@ -27,17 +30,17 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @EntityGraph(attributePaths = {"parent"})
     Optional<Comment> findById(Long id);
 
-    default Comment getParentByIdAndPostId(@Nullable Long parentCommentId, Long postId) {
+    default Comment getParentByIdAndPost(@Nullable Long parentCommentId, Post post) {
         if (parentCommentId == null) {
             return null;
         }
-        return findByIdAndPostId(parentCommentId, postId)
+        return findByIdAndPost(parentCommentId, post)
                 .orElseThrow(NotFoundCommentException::new);
     }
 
-    Optional<Comment> findByIdAndPostId(Long id, Long postId);
+    Optional<Comment> findByIdAndPost(Long id, Post post);
 
     @Modifying
-    @Query("DELETE FROM Comment c WHERE c.post.id = :postId")
-    void deleteAllByPostId(Long postId);
+    @Query("DELETE FROM Comment c WHERE c.post.postId = :postId")
+    void deleteAllByPostId(@Param("postId") PostId postId);
 }

--- a/src/main/java/com/mallang/comment/presentation/CommentController.java
+++ b/src/main/java/com/mallang/comment/presentation/CommentController.java
@@ -74,9 +74,10 @@ public class CommentController {
     public ResponseEntity<List<CommentResponse>> findAll(
             @CookieValue(name = POST_PASSWORD_COOKIE, required = false) String postPassword,
             @Nullable @OptionalAuth Long memberId,
-            @RequestParam(value = "postId", required = true) Long postId
+            @RequestParam(value = "postId", required = true) Long postId,
+            @RequestParam(value = "blogName", required = true) String blogName
     ) {
-        List<CommentResponse> result = commentQueryService.findAllByPostId(postId, memberId, postPassword);
+        List<CommentResponse> result = commentQueryService.findAllByPost(postId, blogName, memberId, postPassword);
         return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/mallang/comment/presentation/request/WriteAuthCommentRequest.java
+++ b/src/main/java/com/mallang/comment/presentation/request/WriteAuthCommentRequest.java
@@ -5,6 +5,7 @@ import jakarta.annotation.Nullable;
 
 public record WriteAuthCommentRequest(
         Long postId,
+        String blogName,
         String content,
         boolean secret,
         @Nullable Long parentCommentId
@@ -13,6 +14,7 @@ public record WriteAuthCommentRequest(
     public WriteAuthCommentCommand toCommand(Long memberId, @Nullable String postPassword) {
         return WriteAuthCommentCommand.builder()
                 .postId(postId)
+                .blogName(blogName)
                 .postPassword(postPassword)
                 .content(content)
                 .secret(secret)

--- a/src/main/java/com/mallang/comment/presentation/request/WriteUnAuthCommentRequest.java
+++ b/src/main/java/com/mallang/comment/presentation/request/WriteUnAuthCommentRequest.java
@@ -5,6 +5,7 @@ import jakarta.annotation.Nullable;
 
 public record WriteUnAuthCommentRequest(
         Long postId,
+        String blogName,
         String content,
         String nickname,
         String password,
@@ -14,6 +15,7 @@ public record WriteUnAuthCommentRequest(
     public WriteUnAuthCommentCommand toCommand(@Nullable String postPassword) {
         return WriteUnAuthCommentCommand.builder()
                 .postId(postId)
+                .blogName(blogName)
                 .postPassword(postPassword)
                 .content(content)
                 .nickname(nickname)

--- a/src/main/java/com/mallang/comment/query/CommentDataPostProcessor.java
+++ b/src/main/java/com/mallang/comment/query/CommentDataPostProcessor.java
@@ -51,8 +51,11 @@ public class CommentDataPostProcessor {
                 .build();
     }
 
-    public List<CommentResponse> processSecret(List<CommentResponse> datas, Long postId, @Nullable Long memberId) {
-        if (isPostWriter(postId, memberId)) {
+    public List<CommentResponse> processSecret(List<CommentResponse> datas,
+                                               Long postId,
+                                               String blogName,
+                                               @Nullable Long memberId) {
+        if (isPostWriter(postId, blogName, memberId)) {
             return datas;
         }
         return datas.stream()
@@ -60,8 +63,8 @@ public class CommentDataPostProcessor {
                 .toList();
     }
 
-    private boolean isPostWriter(Long postId, @Nullable Long memberId) {
-        Post post = postRepository.getById(postId);
+    private boolean isPostWriter(Long postId, String blogName, @Nullable Long memberId) {
+        Post post = postRepository.getByIdAndBlogName(postId, blogName);
         return Objects.equals(post.getWriter().getId(), memberId);
     }
 

--- a/src/main/java/com/mallang/comment/query/CommentDataValidator.java
+++ b/src/main/java/com/mallang/comment/query/CommentDataValidator.java
@@ -16,9 +16,10 @@ public class CommentDataValidator {
     private final PostRepository postRepository;
 
     public void validateAccessPost(Long postId,
+                                   String blogName,
                                    @Nullable Long memberId,
                                    @Nullable String postPassword) {
-        Post post = postRepository.getById(postId);
+        Post post = postRepository.getByIdAndBlogName(postId, blogName);
         Member member = null;
         if (memberId != null) {
             member = memberRepository.getById(memberId);

--- a/src/main/java/com/mallang/comment/query/CommentQueryService.java
+++ b/src/main/java/com/mallang/comment/query/CommentQueryService.java
@@ -17,12 +17,13 @@ public class CommentQueryService {
     private final CommentDataValidator commentDataValidator;
     private final CommentDataPostProcessor commentDataPostProcessor;
 
-    public List<CommentResponse> findAllByPostId(Long postId,
-                                                 @Nullable Long memberId,
-                                                 @Nullable String postPassword) {
-        commentDataValidator.validateAccessPost(postId, memberId, postPassword);
-        List<CommentResponse> result = commentDao.findAllByPostId(postId);
+    public List<CommentResponse> findAllByPost(Long postId,
+                                               String blogName,
+                                               @Nullable Long memberId,
+                                               @Nullable String postPassword) {
+        commentDataValidator.validateAccessPost(postId, blogName, memberId, postPassword);
+        List<CommentResponse> result = commentDao.findAllByPost(postId, blogName);
         List<CommentResponse> deletedProcessedResult = commentDataPostProcessor.processDeleted(result);
-        return commentDataPostProcessor.processSecret(deletedProcessedResult, postId, memberId);
+        return commentDataPostProcessor.processSecret(deletedProcessedResult, postId, blogName, memberId);
     }
 }

--- a/src/main/java/com/mallang/comment/query/dao/CommentDao.java
+++ b/src/main/java/com/mallang/comment/query/dao/CommentDao.java
@@ -15,8 +15,9 @@ public class CommentDao {
 
     private final CommentQuerySupport commentQuerySupport;
 
-    public List<CommentResponse> findAllByPostId(Long postId) {
-        return commentQuerySupport.findAllByPostId(postId).stream()
+    public List<CommentResponse> findAllByPost(Long postId, String blogName) {
+        return commentQuerySupport.findAllByPost(postId, blogName)
+                .stream()
                 .filter(it -> Objects.isNull(it.getParent()))
                 .map(CommentResponse::from)
                 .toList();

--- a/src/main/java/com/mallang/comment/query/supoort/CommentQuerySupport.java
+++ b/src/main/java/com/mallang/comment/query/supoort/CommentQuerySupport.java
@@ -3,8 +3,11 @@ package com.mallang.comment.query.supoort;
 import com.mallang.comment.domain.Comment;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentQuerySupport extends JpaRepository<Comment, Long> {
 
-    List<Comment> findAllByPostId(Long postId);
+    @Query("SELECT c FROM Comment c WHERE c.post.postId.id = :postId AND c.post.blog.name.value = :blogName")
+    List<Comment> findAllByPost(@Param("postId") Long postId, @Param("blogName") String blogName);
 }

--- a/src/main/java/com/mallang/common/domain/DomainEvent.java
+++ b/src/main/java/com/mallang/common/domain/DomainEvent.java
@@ -2,5 +2,5 @@ package com.mallang.common.domain;
 
 public interface DomainEvent {
 
-    Long id();
+    Object id();
 }

--- a/src/main/java/com/mallang/post/application/PostLikeService.java
+++ b/src/main/java/com/mallang/post/application/PostLikeService.java
@@ -24,7 +24,7 @@ public class PostLikeService {
     private final PostLikeValidator postLikeValidator;
 
     public void like(ClickPostLikeCommand command) {
-        Post post = postRepository.getById(command.postId());
+        Post post = postRepository.getByIdAndBlogName(command.postId(), command.blogName());
         Member member = memberRepository.getById(command.memberId());
         PostLike postLike = new PostLike(post, member);
         postLike.like(postLikeValidator, command.postPassword());
@@ -32,7 +32,8 @@ public class PostLikeService {
     }
 
     public void cancel(CancelPostLikeCommand command) {
-        PostLike postLike = postLikeRepository.getByPostIdAndMemberId(command.postId(), command.memberId());
+        PostLike postLike = postLikeRepository
+                .getByPostIdAndMemberId(command.postId(), command.blogName(), command.memberId());
         postLike.cancel(command.postPassword());
         postLikeRepository.delete(postLike);
     }

--- a/src/main/java/com/mallang/post/application/PostStarService.java
+++ b/src/main/java/com/mallang/post/application/PostStarService.java
@@ -24,7 +24,7 @@ public class PostStarService {
     private final PostStarValidator postStarValidator;
 
     public Long star(StarPostCommand command) {
-        Post post = postRepository.getById(command.postId());
+        Post post = postRepository.getByIdAndBlogName(command.postId(), command.blogName());
         Member member = memberRepository.getById(command.memberId());
         PostStar postStar = new PostStar(post, member);
         postStar.star(postStarValidator, command.postPassword());
@@ -33,7 +33,8 @@ public class PostStarService {
     }
 
     public void cancel(CancelPostStarCommand command) {
-        PostStar postStar = postStarRepository.getByPostIdAndMemberId(command.postId(), command.memberId());
+        PostStar postStar = postStarRepository
+                .getByPostIdAndBlogNameAndMemberId(command.postId(), command.blogName(), command.memberId());
         postStarRepository.delete(postStar);
     }
 }

--- a/src/main/java/com/mallang/post/application/command/CancelPostLikeCommand.java
+++ b/src/main/java/com/mallang/post/application/command/CancelPostLikeCommand.java
@@ -4,6 +4,7 @@ import jakarta.annotation.Nullable;
 
 public record CancelPostLikeCommand(
         Long postId,
+        String blogName,
         Long memberId,
         @Nullable String postPassword
 ) {

--- a/src/main/java/com/mallang/post/application/command/CancelPostStarCommand.java
+++ b/src/main/java/com/mallang/post/application/command/CancelPostStarCommand.java
@@ -1,7 +1,8 @@
 package com.mallang.post.application.command;
 
 public record CancelPostStarCommand(
+        Long memberId,
         Long postId,
-        Long memberId
+        String blogName
 ) {
 }

--- a/src/main/java/com/mallang/post/application/command/ClickPostLikeCommand.java
+++ b/src/main/java/com/mallang/post/application/command/ClickPostLikeCommand.java
@@ -4,6 +4,7 @@ import jakarta.annotation.Nullable;
 
 public record ClickPostLikeCommand(
         Long postId,
+        String blogName,
         Long memberId,
         @Nullable String postPassword
 ) {

--- a/src/main/java/com/mallang/post/application/command/CreatePostCommand.java
+++ b/src/main/java/com/mallang/post/application/command/CreatePostCommand.java
@@ -1,12 +1,12 @@
 package com.mallang.post.application.command;
 
 import com.mallang.auth.domain.Member;
-import com.mallang.blog.domain.Blog;
 import com.mallang.category.domain.Category;
 import com.mallang.post.domain.Post;
+import com.mallang.post.domain.PostId;
 import com.mallang.post.domain.PostIntro;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import jakarta.annotation.Nullable;
 import java.util.List;
 import lombok.Builder;
@@ -24,13 +24,12 @@ public record CreatePostCommand(
         @Nullable Long categoryId,
         List<String> tags
 ) {
-    public Post toPost(Member member, Blog blog, Category category, Long postIdInBlog) {
+    public Post toPost(Member member, Category category, PostId postId) {
         return Post.builder()
-                .blog(blog)
+                .postId(postId)
                 .title(title)
                 .content(content)
                 .postThumbnailImageName(postThumbnailImageName)
-                .order(postIdInBlog)
                 .writer(member)
                 .visibilityPolish(new PostVisibilityPolicy(visibility, password))
                 .category(category)

--- a/src/main/java/com/mallang/post/application/command/DeletePostCommand.java
+++ b/src/main/java/com/mallang/post/application/command/DeletePostCommand.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public record DeletePostCommand(
         Long memberId,
-        List<Long> postIds
+        List<Long> postIds,
+        String blogName
 ) {
 }

--- a/src/main/java/com/mallang/post/application/command/StarPostCommand.java
+++ b/src/main/java/com/mallang/post/application/command/StarPostCommand.java
@@ -4,6 +4,7 @@ import jakarta.annotation.Nullable;
 
 public record StarPostCommand(
         Long postId,
+        String blogName,
         Long memberId,
         @Nullable String postPassword
 ) {

--- a/src/main/java/com/mallang/post/application/command/UpdatePostCommand.java
+++ b/src/main/java/com/mallang/post/application/command/UpdatePostCommand.java
@@ -1,6 +1,6 @@
 package com.mallang.post.application.command;
 
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import jakarta.annotation.Nullable;
 import java.util.List;
 import lombok.Builder;
@@ -9,6 +9,7 @@ import lombok.Builder;
 public record UpdatePostCommand(
         Long memberId,
         Long postId,
+        String blogName,
         String title,
         String content,
         @Nullable String postThumbnailImageName,

--- a/src/main/java/com/mallang/post/domain/PostDeleteEvent.java
+++ b/src/main/java/com/mallang/post/domain/PostDeleteEvent.java
@@ -4,16 +4,16 @@ import com.mallang.common.domain.DomainEvent;
 import java.time.LocalDateTime;
 
 public record PostDeleteEvent(
-        Long postId,
+        PostId postId,
         LocalDateTime deletedDate
 ) implements DomainEvent {
 
-    public PostDeleteEvent(Long postId) {
+    public PostDeleteEvent(PostId postId) {
         this(postId, LocalDateTime.now());
     }
 
     @Override
-    public Long id() {
+    public PostId id() {
         return postId();
     }
 }

--- a/src/main/java/com/mallang/post/domain/PostId.java
+++ b/src/main/java/com/mallang/post/domain/PostId.java
@@ -1,0 +1,44 @@
+package com.mallang.post.domain;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+@Embeddable
+public class PostId implements Serializable {
+
+    @Column(name = "post_id", nullable = false, updatable = false)
+    private Long id;
+
+    @Column(name = "blog_id", nullable = false, updatable = false)
+    private Long blogId;
+
+    public PostId(Long id, Long blogId) {
+        this.id = id;
+        this.blogId = blogId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PostId postId)) {
+            return false;
+        }
+        return Objects.equals(getId(), postId.getId())
+                && Objects.equals(getBlogId(), postId.getBlogId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getBlogId());
+    }
+}

--- a/src/main/java/com/mallang/post/domain/PostOrderInBlogGenerator.java
+++ b/src/main/java/com/mallang/post/domain/PostOrderInBlogGenerator.java
@@ -1,6 +1,5 @@
 package com.mallang.post.domain;
 
-import com.mallang.blog.domain.Blog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -10,7 +9,8 @@ public class PostOrderInBlogGenerator {
 
     private final PostRepository postRepository;
 
-    public Long generate(Blog blog) {
-        return postRepository.countByBlog(blog) + 1;
+    public PostId generate(Long blogId) {
+        long postId = postRepository.countByBlog(blogId) + 1;
+        return new PostId(postId, blogId);
     }
 }

--- a/src/main/java/com/mallang/post/domain/PostVisibilityPolicy.java
+++ b/src/main/java/com/mallang/post/domain/PostVisibilityPolicy.java
@@ -1,4 +1,4 @@
-package com.mallang.post.domain.visibility;
+package com.mallang.post.domain;
 
 import com.mallang.post.exception.ProtectVisibilityPasswordMustRequired;
 import com.mallang.post.exception.VisibilityPasswordNotRequired;

--- a/src/main/java/com/mallang/post/domain/Tag.java
+++ b/src/main/java/com/mallang/post/domain/Tag.java
@@ -1,19 +1,33 @@
 package com.mallang.post.domain;
 
+import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
-import com.mallang.common.domain.CommonDomainModel;
 import com.mallang.post.exception.BadTagContentException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Entity
-public class Tag extends CommonDomainModel {
+@EntityListeners(AuditingEntityListener.class)
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    private LocalDateTime createdDate;
 
     @Column(nullable = false, length = 30)
     private String content;

--- a/src/main/java/com/mallang/post/domain/like/PostLike.java
+++ b/src/main/java/com/mallang/post/domain/like/PostLike.java
@@ -8,6 +8,7 @@ import com.mallang.post.domain.Post;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -19,7 +20,10 @@ import lombok.NoArgsConstructor;
 public class PostLike extends CommonDomainModel {
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "post_id")
+    @JoinColumns({
+            @JoinColumn(name = "post_id", referencedColumnName = "post_id"),
+            @JoinColumn(name = "blog_id", referencedColumnName = "blog_id"),
+    })
     private Post post;
 
     @ManyToOne(fetch = LAZY)

--- a/src/main/java/com/mallang/post/domain/like/PostLikeRepository.java
+++ b/src/main/java/com/mallang/post/domain/like/PostLikeRepository.java
@@ -2,6 +2,7 @@ package com.mallang.post.domain.like;
 
 import com.mallang.auth.domain.Member;
 import com.mallang.post.domain.Post;
+import com.mallang.post.domain.PostId;
 import com.mallang.post.exception.NotFoundPostLikeException;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,14 +14,22 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     boolean existsByPostAndMember(Post post, Member member);
 
-    default PostLike getByPostIdAndMemberId(Long postId, Long memberId) {
-        return findByPostIdAndMemberId(postId, memberId)
+    default PostLike getByPostIdAndMemberId(Long postId, String blogName, Long memberId) {
+        return findByPostIdAndMemberId(postId, blogName, memberId)
                 .orElseThrow(NotFoundPostLikeException::new);
     }
 
-    Optional<PostLike> findByPostIdAndMemberId(Long postId, Long memberId);
+    @Query("""
+            SELECT pl FROM PostLike pl
+            WHERE pl.post.postId.id = :postId
+            AND pl.post.blog.name.value = :blogName
+            AND pl.member.id = :memberId
+            """)
+    Optional<PostLike> findByPostIdAndMemberId(@Param("postId") Long postId,
+                                               @Param("blogName") String blogName,
+                                               @Param("memberId") Long memberId);
 
     @Modifying
-    @Query("DELETE FROM PostLike pl WHERE pl.post.id = :postId")
-    void deleteAllByPostId(@Param("postId") Long postId);
+    @Query("DELETE FROM PostLike pl WHERE pl.post.postId = :postId")
+    void deleteAllByPostId(@Param("postId") PostId postId);
 }

--- a/src/main/java/com/mallang/post/domain/star/PostStar.java
+++ b/src/main/java/com/mallang/post/domain/star/PostStar.java
@@ -8,6 +8,7 @@ import com.mallang.post.domain.Post;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -19,7 +20,10 @@ import lombok.NoArgsConstructor;
 public class PostStar extends CommonDomainModel {
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "post_id")
+    @JoinColumns({
+            @JoinColumn(name = "post_id", referencedColumnName = "post_id"),
+            @JoinColumn(name = "blog_id", referencedColumnName = "blog_id"),
+    })
     private Post post;
 
     @ManyToOne(fetch = LAZY)

--- a/src/main/java/com/mallang/post/domain/star/PostStarRepository.java
+++ b/src/main/java/com/mallang/post/domain/star/PostStarRepository.java
@@ -2,6 +2,7 @@ package com.mallang.post.domain.star;
 
 import com.mallang.auth.domain.Member;
 import com.mallang.post.domain.Post;
+import com.mallang.post.domain.PostId;
 import com.mallang.post.exception.NotFoundPostStarException;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,14 +14,22 @@ public interface PostStarRepository extends JpaRepository<PostStar, Long> {
 
     boolean existsByPostAndMember(Post post, Member member);
 
-    default PostStar getByPostIdAndMemberId(Long postId, Long memberId) {
-        return findByPostIdAndMemberId(postId, memberId)
+    default PostStar getByPostIdAndBlogNameAndMemberId(Long postId, String blogName, Long memberId) {
+        return findByPostIdAndBlogNameAndMemberId(postId, blogName, memberId)
                 .orElseThrow(NotFoundPostStarException::new);
     }
 
-    Optional<PostStar> findByPostIdAndMemberId(Long postId, Long memberId);
+    @Query("""
+            SELECT ps FROM PostStar ps
+            WHERE ps.post.postId.id = :postId
+            AND ps.post.blog.name.value = :blogName
+            AND ps.member.id = :memberId
+            """)
+    Optional<PostStar> findByPostIdAndBlogNameAndMemberId(@Param("postId") Long postId,
+                                                          @Param("blogName") String blogName,
+                                                          @Param("memberId") Long memberId);
 
     @Modifying
-    @Query("DELETE FROM PostStar ps WHERE ps.post.id = :postId")
-    void deleteAllByPostId(@Param("postId") Long postId);
+    @Query("DELETE FROM PostStar ps WHERE ps.post.postId = :postId")
+    void deleteAllByPostId(@Param("postId") PostId postId);
 }

--- a/src/main/java/com/mallang/post/presentation/PostController.java
+++ b/src/main/java/com/mallang/post/presentation/PostController.java
@@ -26,13 +26,14 @@ public class PostController {
 
     private final PostQueryService postQueryService;
 
-    @GetMapping("/{id}")
+    @GetMapping("/{blogName}/{id}")
     public ResponseEntity<PostDetailResponse> getById(
             @OptionalAuth Long memberId,
             @CookieValue(name = POST_PASSWORD_COOKIE, required = false) String postPassword,
+            @PathVariable(name = "blogName") String blogName,
             @PathVariable(name = "id") Long id
     ) {
-        return ResponseEntity.ok(postQueryService.getById(memberId, postPassword, id));
+        return ResponseEntity.ok(postQueryService.getByIdAndBlogName(id, blogName, memberId, postPassword));
     }
 
     @GetMapping
@@ -41,6 +42,6 @@ public class PostController {
             @ModelAttribute PostSearchCond postSearchCond,
             @PageableDefault(size = 9) Pageable pageable
     ) {
-        return ResponseEntity.ok(PageResponse.from(postQueryService.search(memberId, postSearchCond, pageable)));
+        return ResponseEntity.ok(PageResponse.from(postQueryService.search(postSearchCond, pageable, memberId)));
     }
 }

--- a/src/main/java/com/mallang/post/presentation/PostManageController.java
+++ b/src/main/java/com/mallang/post/presentation/PostManageController.java
@@ -3,6 +3,7 @@ package com.mallang.post.presentation;
 import com.mallang.auth.presentation.support.Auth;
 import com.mallang.common.presentation.PageResponse;
 import com.mallang.post.application.PostService;
+import com.mallang.post.domain.PostId;
 import com.mallang.post.presentation.request.CreatePostRequest;
 import com.mallang.post.presentation.request.DeletePostRequest;
 import com.mallang.post.presentation.request.UpdatePostRequest;
@@ -38,8 +39,9 @@ public class PostManageController {
             @Auth Long memberId,
             @RequestBody CreatePostRequest request
     ) {
-        Long id = postService.create(request.toCommand(memberId));
-        return ResponseEntity.created(URI.create("/posts/" + id)).build();
+        PostId id = postService.create(request.toCommand(memberId));
+        URI uri = URI.create("/posts/%s/%d".formatted(request.blogName(), id.getId()));
+        return ResponseEntity.created(uri).build();
     }
 
     @PutMapping("/{id}")
@@ -61,12 +63,13 @@ public class PostManageController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/{blogName}/{id}")
     public ResponseEntity<PostManageDetailResponse> getById(
+            @PathVariable(name = "blogName") String blogName,
             @PathVariable(name = "id") Long postId,
             @Auth Long memberId
     ) {
-        return ResponseEntity.ok(postManageQueryService.findById(memberId, postId));
+        return ResponseEntity.ok(postManageQueryService.findById(memberId, postId, blogName));
     }
 
     @GetMapping

--- a/src/main/java/com/mallang/post/presentation/request/CancelPostLikeRequest.java
+++ b/src/main/java/com/mallang/post/presentation/request/CancelPostLikeRequest.java
@@ -4,10 +4,11 @@ import com.mallang.post.application.command.CancelPostLikeCommand;
 import jakarta.annotation.Nullable;
 
 public record CancelPostLikeRequest(
-        Long postId
+        Long postId,
+        String blogName
 ) {
 
     public CancelPostLikeCommand toCommand(Long memberId, @Nullable String postPassword) {
-        return new CancelPostLikeCommand(postId, memberId, postPassword);
+        return new CancelPostLikeCommand(postId, blogName, memberId, postPassword);
     }
 }

--- a/src/main/java/com/mallang/post/presentation/request/CancelPostStarRequest.java
+++ b/src/main/java/com/mallang/post/presentation/request/CancelPostStarRequest.java
@@ -3,10 +3,11 @@ package com.mallang.post.presentation.request;
 import com.mallang.post.application.command.CancelPostStarCommand;
 
 public record CancelPostStarRequest(
-        Long postId
+        Long postId,
+        String blogName
 ) {
 
     public CancelPostStarCommand toCommand(Long memberId) {
-        return new CancelPostStarCommand(postId, memberId);
+        return new CancelPostStarCommand(memberId, postId, blogName);
     }
 }

--- a/src/main/java/com/mallang/post/presentation/request/ClickPostLikeRequest.java
+++ b/src/main/java/com/mallang/post/presentation/request/ClickPostLikeRequest.java
@@ -4,10 +4,11 @@ import com.mallang.post.application.command.ClickPostLikeCommand;
 import jakarta.annotation.Nullable;
 
 public record ClickPostLikeRequest(
-        Long postId
+        Long postId,
+        String blogName
 ) {
 
     public ClickPostLikeCommand toCommand(Long memberId, @Nullable String postPassword) {
-        return new ClickPostLikeCommand(postId, memberId, postPassword);
+        return new ClickPostLikeCommand(postId, blogName, memberId, postPassword);
     }
 }

--- a/src/main/java/com/mallang/post/presentation/request/CreatePostRequest.java
+++ b/src/main/java/com/mallang/post/presentation/request/CreatePostRequest.java
@@ -1,7 +1,7 @@
 package com.mallang.post.presentation.request;
 
 import com.mallang.post.application.command.CreatePostCommand;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import jakarta.annotation.Nullable;
 import java.util.List;
 

--- a/src/main/java/com/mallang/post/presentation/request/DeletePostRequest.java
+++ b/src/main/java/com/mallang/post/presentation/request/DeletePostRequest.java
@@ -4,9 +4,10 @@ import com.mallang.post.application.command.DeletePostCommand;
 import java.util.List;
 
 public record DeletePostRequest(
-        List<Long> postIds
+        List<Long> postIds,
+        String blogName
 ) {
     public DeletePostCommand toCommand(Long memberId) {
-        return new DeletePostCommand(memberId, postIds);
+        return new DeletePostCommand(memberId, postIds, blogName);
     }
 }

--- a/src/main/java/com/mallang/post/presentation/request/StarPostRequest.java
+++ b/src/main/java/com/mallang/post/presentation/request/StarPostRequest.java
@@ -4,10 +4,11 @@ import com.mallang.post.application.command.StarPostCommand;
 import jakarta.annotation.Nullable;
 
 public record StarPostRequest(
-        Long postId
+        Long postId,
+        String blogName
 ) {
 
     public StarPostCommand toCommand(Long memberId, @Nullable String postPassword) {
-        return new StarPostCommand(postId, memberId, postPassword);
+        return new StarPostCommand(postId, blogName, memberId, postPassword);
     }
 }

--- a/src/main/java/com/mallang/post/presentation/request/UpdatePostRequest.java
+++ b/src/main/java/com/mallang/post/presentation/request/UpdatePostRequest.java
@@ -1,11 +1,12 @@
 package com.mallang.post.presentation.request;
 
 import com.mallang.post.application.command.UpdatePostCommand;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import jakarta.annotation.Nullable;
 import java.util.List;
 
 public record UpdatePostRequest(
+        String blogName,
         String title,
         String content,
         @Nullable String postThumbnailImageName,
@@ -20,6 +21,7 @@ public record UpdatePostRequest(
         return UpdatePostCommand.builder()
                 .memberId(memberId)
                 .postId(postId)
+                .blogName(blogName)
                 .title(title)
                 .content(content)
                 .postThumbnailImageName(postThumbnailImageName)

--- a/src/main/java/com/mallang/post/query/PostDataProtector.java
+++ b/src/main/java/com/mallang/post/query/PostDataProtector.java
@@ -1,6 +1,6 @@
 package com.mallang.post.query;
 
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import com.mallang.post.query.response.PostDetailResponse;
 import com.mallang.post.query.response.PostSearchResponse;
 import com.mallang.post.query.response.StaredPostResponse;
@@ -28,6 +28,7 @@ public class PostDataProtector {
         }
         return new PostDetailResponse(
                 postDetailResponse.id(),
+                postDetailResponse.blogName(),
                 postDetailResponse.title(),
                 "보호되어 있는 글입니다. 내용을 보시려면 비밀번호를 입력하세요.",
                 "",
@@ -57,6 +58,7 @@ public class PostDataProtector {
         }
         return new PostSearchResponse(
                 postSearchResponse.id(),
+                postSearchResponse.blogName(),
                 postSearchResponse.title(),
                 "보호되어 있는 글입니다.",
                 "",
@@ -91,6 +93,7 @@ public class PostDataProtector {
                 data.starId(),
                 data.staredData(),
                 data.postId(),
+                data.blogName(),
                 data.title(),
                 "보호되어 있는 글입니다.",
                 "",

--- a/src/main/java/com/mallang/post/query/PostDataValidator.java
+++ b/src/main/java/com/mallang/post/query/PostDataValidator.java
@@ -1,6 +1,6 @@
 package com.mallang.post.query;
 
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import com.mallang.post.exception.NoAuthorityAccessPostException;
 import com.mallang.post.query.response.PostDetailResponse;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/mallang/post/query/PostManageQueryService.java
+++ b/src/main/java/com/mallang/post/query/PostManageQueryService.java
@@ -19,8 +19,8 @@ public class PostManageQueryService {
     private final PostManageDetailDao postManageDetailDao;
     private final PostManageSearchDao postManageSearchDao;
 
-    public PostManageDetailResponse findById(Long memberId, Long id) {
-        return postManageDetailDao.find(memberId, id);
+    public PostManageDetailResponse findById(Long memberId, Long id, String blogName) {
+        return postManageDetailDao.find(memberId, id, blogName);
     }
 
     public Page<PostManageSearchResponse> search(Long memberId, PostManageSearchCond cond, Pageable pageable) {

--- a/src/main/java/com/mallang/post/query/PostQueryService.java
+++ b/src/main/java/com/mallang/post/query/PostQueryService.java
@@ -22,13 +22,16 @@ public class PostQueryService {
     private final PostDataValidator postDataValidator;
     private final PostDataProtector postDataProtector;
 
-    public PostDetailResponse getById(@Nullable Long memberId, @Nullable String postPassword, Long id) {
-        PostDetailResponse postDetailResponse = postDetailDao.find(memberId, id);
+    public PostDetailResponse getByIdAndBlogName(Long id,
+                                                 String blogName,
+                                                 @Nullable Long memberId,
+                                                 @Nullable String postPassword) {
+        PostDetailResponse postDetailResponse = postDetailDao.find(id, blogName, memberId);
         postDataValidator.validateAccessPost(memberId, postDetailResponse);
         return postDataProtector.protectIfRequired(memberId, postPassword, postDetailResponse);
     }
 
-    public Page<PostSearchResponse> search(@Nullable Long memberId, PostSearchCond cond, Pageable pageable) {
+    public Page<PostSearchResponse> search(PostSearchCond cond, Pageable pageable, @Nullable Long memberId) {
         Page<PostSearchResponse> result = postSearchDao.search(memberId, cond, pageable);
         return postDataProtector.protectIfRequired(memberId, result);
     }

--- a/src/main/java/com/mallang/post/query/dao/PostDetailDao.java
+++ b/src/main/java/com/mallang/post/query/dao/PostDetailDao.java
@@ -16,11 +16,11 @@ public class PostDetailDao {
     private final PostQuerySupport postQuerySupport;
     private final PostLikeQuerySupport postLikeQuerySupport;
 
-    public PostDetailResponse find(@Nullable Long memberId, Long id) {
+    public PostDetailResponse find(Long id, String blogName, @Nullable Long memberId) {
         if (memberId == null) {
-            return PostDetailResponse.from(postQuerySupport.getById(id));
+            return PostDetailResponse.from(postQuerySupport.getByIdAndBlogName(id, blogName));
         }
-        boolean isLiked = postLikeQuerySupport.existsByMemberIdAndPostId(memberId, id);
-        return PostDetailResponse.withLiked(postQuerySupport.getById(id), isLiked);
+        boolean isLiked = postLikeQuerySupport.existsByMemberIdAndPostId(memberId, id, blogName);
+        return PostDetailResponse.withLiked(postQuerySupport.getByIdAndBlogName(id, blogName), isLiked);
     }
 }

--- a/src/main/java/com/mallang/post/query/dao/PostManageDetailDao.java
+++ b/src/main/java/com/mallang/post/query/dao/PostManageDetailDao.java
@@ -13,7 +13,8 @@ public class PostManageDetailDao {
 
     private final PostQuerySupport postQuerySupport;
 
-    public PostManageDetailResponse find(Long memberId, Long id) {
-        return PostManageDetailResponse.from(postQuerySupport.getByIdAndWriterId(id, memberId));
+    public PostManageDetailResponse find(Long memberId, Long id, String blogName) {
+        return PostManageDetailResponse.from(postQuerySupport
+                .getByPostIdAndBlogNameAndWriterId(id, blogName, memberId));
     }
 }

--- a/src/main/java/com/mallang/post/query/dao/PostManageSearchDao.java
+++ b/src/main/java/com/mallang/post/query/dao/PostManageSearchDao.java
@@ -6,7 +6,7 @@ import static com.mallang.post.query.dao.PostManageSearchDao.PostManageSearchCon
 
 import com.mallang.category.query.support.CategoryQuerySupport;
 import com.mallang.post.domain.Post;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import com.mallang.post.query.response.PostManageSearchResponse;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -51,7 +51,7 @@ public class PostManageSearchDao {
                         contentContains(cond.content()),
                         visibilityEq(cond.visibility())
                 )
-                .orderBy(post.id.desc())
+                .orderBy(post.postId.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/com/mallang/post/query/dao/PostSearchDao.java
+++ b/src/main/java/com/mallang/post/query/dao/PostSearchDao.java
@@ -1,10 +1,11 @@
 package com.mallang.post.query.dao;
 
 import static com.mallang.auth.domain.QMember.member;
+import static com.mallang.blog.domain.QBlog.blog;
 import static com.mallang.category.domain.QCategory.category;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
 import static com.mallang.post.domain.QPost.post;
 import static com.mallang.post.domain.QTag.tag;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
 import static org.springframework.data.support.PageableExecutionUtils.getPage;
 
 import com.mallang.category.query.support.CategoryQuerySupport;
@@ -45,6 +46,7 @@ public class PostSearchDao {
                 );
         List<Post> result = query.selectFrom(post)
                 .distinct()
+                .leftJoin(post.blog, blog).fetchJoin()
                 .leftJoin(post.tags, tag)
                 .join(post.writer, member).fetchJoin()
                 .leftJoin(post.category, category).fetchJoin()
@@ -56,7 +58,7 @@ public class PostSearchDao {
                         writerIdEq(cond.writerId()),
                         titleOrContentContains(cond.title(), cond.content(), cond.titleOrContent())
                 )
-                .orderBy(post.id.desc())
+                .orderBy(post.createdDate.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/com/mallang/post/query/dao/StaredPostDao.java
+++ b/src/main/java/com/mallang/post/query/dao/StaredPostDao.java
@@ -1,9 +1,9 @@
 package com.mallang.post.query.dao;
 
 import static com.mallang.auth.domain.QMember.member;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
 import static com.mallang.post.domain.QPost.post;
 import static com.mallang.post.domain.star.QPostStar.postStar;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
 
 import com.mallang.post.domain.star.PostStar;
 import com.mallang.post.query.response.StaredPostResponse;

--- a/src/main/java/com/mallang/post/query/response/PostDetailResponse.java
+++ b/src/main/java/com/mallang/post/query/response/PostDetailResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.mallang.auth.domain.Member;
 import com.mallang.category.domain.Category;
 import com.mallang.post.domain.Post;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import jakarta.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,6 +13,7 @@ import lombok.Builder;
 @Builder
 public record PostDetailResponse(
         Long id,
+        String blogName,
         String title,
         String content,
         @Nullable String postThumbnailImageName,
@@ -32,7 +33,8 @@ public record PostDetailResponse(
 
     public static PostDetailResponse withLiked(Post post, boolean isLiked) {
         return PostDetailResponse.builder()
-                .id(post.getId())
+                .id(post.getPostId().getId())
+                .blogName(post.getBlog().getName())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .postThumbnailImageName(post.getPostThumbnailImageName())

--- a/src/main/java/com/mallang/post/query/response/PostManageDetailResponse.java
+++ b/src/main/java/com/mallang/post/query/response/PostManageDetailResponse.java
@@ -2,7 +2,7 @@ package com.mallang.post.query.response;
 
 import com.mallang.category.domain.Category;
 import com.mallang.post.domain.Post;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import jakarta.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,7 +23,7 @@ public record PostManageDetailResponse(
 ) {
     public static PostManageDetailResponse from(Post post) {
         return PostManageDetailResponse.builder()
-                .id(post.getId())
+                .id(post.getPostId().getId())
                 .title(post.getTitle())
                 .intro(post.getPostIntro())
                 .content(post.getContent())

--- a/src/main/java/com/mallang/post/query/response/PostManageSearchResponse.java
+++ b/src/main/java/com/mallang/post/query/response/PostManageSearchResponse.java
@@ -2,7 +2,7 @@ package com.mallang.post.query.response;
 
 import com.mallang.category.domain.Category;
 import com.mallang.post.domain.Post;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import java.time.LocalDateTime;
 import lombok.Builder;
 
@@ -17,7 +17,7 @@ public record PostManageSearchResponse(
 ) {
     public static PostManageSearchResponse from(Post post) {
         return PostManageSearchResponse.builder()
-                .id(post.getId())
+                .id(post.getPostId().getId())
                 .title(post.getTitle())
                 .visibility(post.getVisibilityPolish().getVisibility())
                 .password(post.getVisibilityPolish().getPassword())

--- a/src/main/java/com/mallang/post/query/response/PostSearchResponse.java
+++ b/src/main/java/com/mallang/post/query/response/PostSearchResponse.java
@@ -3,7 +3,7 @@ package com.mallang.post.query.response;
 import com.mallang.auth.domain.Member;
 import com.mallang.category.domain.Category;
 import com.mallang.post.domain.Post;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import jakarta.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,6 +12,7 @@ import lombok.Builder;
 @Builder
 public record PostSearchResponse(
         Long id,
+        String blogName,
         String title,
         String content,
         String intro,
@@ -25,7 +26,8 @@ public record PostSearchResponse(
 ) {
     public static PostSearchResponse from(Post post) {
         return PostSearchResponse.builder()
-                .id(post.getId())
+                .id(post.getPostId().getId())
+                .blogName(post.getBlog().getName())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .intro(post.getPostIntro())

--- a/src/main/java/com/mallang/post/query/response/StaredPostResponse.java
+++ b/src/main/java/com/mallang/post/query/response/StaredPostResponse.java
@@ -3,8 +3,8 @@ package com.mallang.post.query.response;
 import com.mallang.auth.domain.Member;
 import com.mallang.category.domain.Category;
 import com.mallang.post.domain.Post;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import com.mallang.post.domain.star.PostStar;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
 import jakarta.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,6 +15,7 @@ public record StaredPostResponse(
         Long starId,
         LocalDateTime staredData,
         Long postId,
+        String blogName,
         String title,
         String content,
         String intro,
@@ -30,7 +31,8 @@ public record StaredPostResponse(
         return StaredPostResponse.builder()
                 .starId(postStar.getId())
                 .staredData(postStar.getCreatedDate())
-                .postId(post.getId())
+                .postId(post.getPostId().getId())
+                .blogName(post.getBlog().getName())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .intro(post.getPostIntro())

--- a/src/main/java/com/mallang/post/query/support/PostLikeQuerySupport.java
+++ b/src/main/java/com/mallang/post/query/support/PostLikeQuerySupport.java
@@ -10,15 +10,21 @@ public interface PostLikeQuerySupport extends JpaRepository<PostLike, Long> {
 
     default boolean existsByMemberIdAndPostId(
             Long memberId,
-            Long postId
+            Long postId,
+            String blogName
     ) {
-        // TODO 이거 VS findTop1ByMemberIdAndBlogNameAndPostId 이거랑 성능차이 있나 확인하기
-        return findByMemberIdAndPostId(memberId, postId).isPresent();
+        return findByMemberIdAndPostId(memberId, postId, blogName).isPresent();
     }
 
-    @Query("SELECT pl FROM PostLike pl WHERE pl.member.id = :memberId AND pl.post.id = :postId")
+    @Query("""
+            SELECT pl FROM PostLike pl
+            WHERE pl.member.id = :memberId
+            AND pl.post.postId.id = :postId
+            AND pl.post.blog.name.value = :blogName
+            """)
     Optional<PostLike> findByMemberIdAndPostId(
             @Param("memberId") Long memberId,
-            @Param("postId") Long postId
+            @Param("postId") Long postId,
+            @Param("blogName") String blogName
     );
 }

--- a/src/main/java/com/mallang/post/query/support/PostQuerySupport.java
+++ b/src/main/java/com/mallang/post/query/support/PostQuerySupport.java
@@ -4,16 +4,33 @@ import com.mallang.post.domain.Post;
 import com.mallang.post.exception.NotFoundPostException;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostQuerySupport extends JpaRepository<Post, Long> {
 
-    default Post getById(Long id) {
-        return findById(id).orElseThrow(NotFoundPostException::new);
+    default Post getByIdAndBlogName(Long id, String blogName) {
+        return findByIdAndBlogName(id, blogName)
+                .orElseThrow(NotFoundPostException::new);
     }
 
-    default Post getByIdAndWriterId(Long id, Long writerId) {
-        return findByIdAndWriterId(id, writerId).orElseThrow(NotFoundPostException::new);
+    @Query("SELECT p FROM Post p WHERE p.postId.id = :id AND p.blog.name.value = :blogName")
+    Optional<Post> findByIdAndBlogName(@Param("id") Long id,
+                                       @Param("blogName") String blogName);
+
+    default Post getByPostIdAndBlogNameAndWriterId(Long id, String blogName, Long writerId) {
+        return findByPostIdAndBlogNameAndWriterId(id, blogName, writerId).orElseThrow(NotFoundPostException::new);
     }
 
-    Optional<Post> findByIdAndWriterId(Long id, Long writerId);
+    @Query("""
+            SELECT p FROM  Post p
+            WHERE p.postId.id = :id
+            AND p.blog.name.value = :blogName
+            AND p.writer.id = :writerId
+            """)
+    Optional<Post> findByPostIdAndBlogNameAndWriterId(
+            @Param("id") Long id,
+            @Param("blogName") String blogName,
+            @Param("writerId") Long writerId
+    );
 }

--- a/src/main/java/com/mallang/statistics/statistic/collector/PostViewHistoryAop.java
+++ b/src/main/java/com/mallang/statistics/statistic/collector/PostViewHistoryAop.java
@@ -27,12 +27,12 @@ public class PostViewHistoryAop {
 
     private final PostViewHistoryCollector postViewHistoryCollector;
 
-    @Pointcut("execution(* com.mallang.post.query.PostQueryService.getById(..))")
-    public void postQueryServiceGetById() {
+    @Pointcut("execution(* com.mallang.post.query.PostQueryService.getByIdAndBlogName(..))")
+    public void postQueryServiceGetByIdAndBlogName() {
     }
 
     @AfterReturning(
-            pointcut = "postQueryServiceGetById()",
+            pointcut = "postQueryServiceGetByIdAndBlogName()",
             returning = "result"
     )
     public void history(PostDetailResponse result) {

--- a/src/test/java/com/mallang/acceptance/category/CategoryAcceptanceTest.java
+++ b/src/test/java/com/mallang/acceptance/category/CategoryAcceptanceTest.java
@@ -18,7 +18,7 @@ import static com.mallang.acceptance.category.CategoryAcceptanceSteps.카테고�
 import static com.mallang.acceptance.category.CategoryAcceptanceSteps.카테고리_조회_응답을_검증한다;
 import static com.mallang.acceptance.post.PostAcceptanceSteps.포스트_단일_조회_요청;
 import static com.mallang.acceptance.post.PostManageAcceptanceSteps.포스트_생성;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PUBLIC;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PUBLIC;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -152,7 +152,8 @@ class CategoryAcceptanceTest extends AcceptanceTest {
 
             // then
             응답_상태를_검증한다(응답, 정상_처리);
-            var 포스트_조회_응답 = 포스트_단일_조회_요청(null, 포스트_ID, null).as(PostDetailResponse.class);
+            var 포스트_조회_응답 = 포스트_단일_조회_요청(null, 포스트_ID, 말랑_블로그_이름, null)
+                    .as(PostDetailResponse.class);
             assertThat(포스트_조회_응답.category().categoryId()).isNull();
         }
 

--- a/src/test/java/com/mallang/acceptance/comment/CommentAcceptanceSteps.java
+++ b/src/test/java/com/mallang/acceptance/comment/CommentAcceptanceSteps.java
@@ -139,19 +139,22 @@ public class CommentAcceptanceSteps {
 
     public static ExtractableResponse<Response> 특정_포스트의_댓글_전체_조회_요청(
             Long 포스트_ID,
+            String 블로그_이름,
             @Nullable String 포스트_비밀번호
     ) {
-        return 특정_포스트의_댓글_전체_조회_요청(null, 포스트_ID, 포스트_비밀번호);
+        return 특정_포스트의_댓글_전체_조회_요청(null, 포스트_ID, 블로그_이름, 포스트_비밀번호);
     }
 
     public static ExtractableResponse<Response> 특정_포스트의_댓글_전체_조회_요청(
             String 세션_ID,
             Long 포스트_ID,
+            String 블로그_이름,
             @Nullable String 포스트_비밀번호
     ) {
         return given(세션_ID)
                 .cookie(POST_PASSWORD_COOKIE, 포스트_비밀번호)
                 .queryParam("postId", 포스트_ID)
+                .queryParam("blogName", 블로그_이름)
                 .get("/comments")
                 .then().log().all()
                 .extract();

--- a/src/test/java/com/mallang/acceptance/comment/CommentAcceptanceTest.java
+++ b/src/test/java/com/mallang/acceptance/comment/CommentAcceptanceTest.java
@@ -27,7 +27,7 @@ import static com.mallang.acceptance.post.PostManageAcceptanceSteps.보호_포�
 import static com.mallang.acceptance.post.PostManageAcceptanceSteps.비공개_포스트_생성_데이터;
 import static com.mallang.acceptance.post.PostManageAcceptanceSteps.포스트_생성;
 import static com.mallang.acceptance.post.PostManageAcceptanceSteps.포스트_수정_요청;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
 import static java.util.Collections.emptyList;
 
 import com.mallang.acceptance.AcceptanceTest;
@@ -74,9 +74,10 @@ class CommentAcceptanceTest extends AcceptanceTest {
         공개_포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(말랑_블로그_이름));
         보호_포스트_ID = 포스트_생성(말랑_세션_ID, 보호_포스트_생성_데이터(말랑_블로그_이름));
         비공개_포스트_ID = 포스트_생성(말랑_세션_ID, 비공개_포스트_생성_데이터(말랑_블로그_이름));
-        비인증_댓글_작성_요청 = new WriteUnAuthCommentRequest(공개_포스트_ID, "댓글", "비인증", "1234", null);
-        인증_댓글_작성_요청 = new WriteAuthCommentRequest(공개_포스트_ID, "댓글", 공개, null);
+        비인증_댓글_작성_요청 = new WriteUnAuthCommentRequest(공개_포스트_ID, 말랑_블로그_이름, "댓글", "비인증", "1234", null);
+        인증_댓글_작성_요청 = new WriteAuthCommentRequest(공개_포스트_ID, 말랑_블로그_이름, "댓글", 공개, null);
         공개_포스트를_비공개로_바꾸는_요청 = new UpdatePostRequest(
+                말랑_블로그_이름,
                 "보호로 변경",
                 "보호",
                 null,
@@ -112,7 +113,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
         @Test
         void 로그인한_사용자는_비밀_댓글을_작성할_수_있다() {
             // when
-            var 비공개_댓글_작성_요청 = new WriteAuthCommentRequest(공개_포스트_ID, "댓글", 비공개, null);
+            var 비공개_댓글_작성_요청 = new WriteAuthCommentRequest(공개_포스트_ID, 말랑_블로그_이름, "댓글", 비공개, null);
             var 응답 = 댓글_작성_요청(동훈_세션_ID, 비공개_댓글_작성_요청, null);
 
             // then
@@ -123,7 +124,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
         void 대댓글을_작성할_수_있다() {
             // given
             var 댓글_ID = 댓글_작성(동훈_세션_ID, 인증_댓글_작성_요청, null);
-            var 대댓글_작성_요청 = new WriteAuthCommentRequest(공개_포스트_ID, "대댓글", 비공개, 댓글_ID);
+            var 대댓글_작성_요청 = new WriteAuthCommentRequest(공개_포스트_ID, 말랑_블로그_이름, "대댓글", 비공개, 댓글_ID);
 
             // when
             var 응답 = 댓글_작성_요청(동훈_세션_ID, 대댓글_작성_요청, null);
@@ -136,9 +137,9 @@ class CommentAcceptanceTest extends AcceptanceTest {
         void 대댓글에_대해_댓글을_달_수_없다() {
             // given
             var 댓글_ID = 댓글_작성(동훈_세션_ID, 인증_댓글_작성_요청, null);
-            var 대댓글_작성_요청 = new WriteAuthCommentRequest(공개_포스트_ID, "대댓글", 비공개, 댓글_ID);
+            var 대댓글_작성_요청 = new WriteAuthCommentRequest(공개_포스트_ID, 말랑_블로그_이름, "대댓글", 비공개, 댓글_ID);
             var 대댓글_ID = 댓글_작성(동훈_세션_ID, 대댓글_작성_요청, null);
-            var 대대댓글_작성_요청 = new WriteAuthCommentRequest(공개_포스트_ID, "대대댓글", 비공개, 대댓글_ID);
+            var 대대댓글_작성_요청 = new WriteAuthCommentRequest(공개_포스트_ID, 말랑_블로그_이름, "대대댓글", 비공개, 대댓글_ID);
 
             // when
             var 응답 = 댓글_작성_요청(동훈_세션_ID, 대대댓글_작성_요청, null);
@@ -154,7 +155,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
 
             @BeforeEach
             void setUp() {
-                댓글_작성_요청 = new WriteAuthCommentRequest(보호_포스트_ID, "댓글", 비공개, null);
+                댓글_작성_요청 = new WriteAuthCommentRequest(보호_포스트_ID, 말랑_블로그_이름, "댓글", 비공개, null);
             }
 
             @Nested
@@ -188,7 +189,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
                 void 대댓글로_남기는_것_역시_불가하다() {
                     // given
                     var 댓글_ID = 댓글_작성(동훈_세션_ID, 댓글_작성_요청, "1234");
-                    var 대댓글_작성_요청 = new WriteAuthCommentRequest(보호_포스트_ID, "댓글", 비공개, 댓글_ID);
+                    var 대댓글_작성_요청 = new WriteAuthCommentRequest(보호_포스트_ID, 말랑_블로그_이름, "댓글", 비공개, 댓글_ID);
 
                     // when
                     var 응답 = 댓글_작성_요청(동훈_세션_ID, 대댓글_작성_요청, null);
@@ -200,7 +201,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
                 @Test
                 void 회원가입_여부에_관계없이_입력한_비밀번호가_포스트의_비밀번호와_일치하면_작성할_수_있다() {
                     // when
-                    var 댓글_작성_요청 = new WriteUnAuthCommentRequest(보호_포스트_ID, "댓글", "익명입니다", "댓글비번", null);
+                    var 댓글_작성_요청 = new WriteUnAuthCommentRequest(보호_포스트_ID, 말랑_블로그_이름, "댓글", "익명입니다", "댓글비번", null);
                     var 응답 = 비인증_댓글_작성_요청(댓글_작성_요청, "1234");
 
                     // then
@@ -216,7 +217,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
 
             @BeforeEach
             void setUp() {
-                댓글_작성_요청 = new WriteAuthCommentRequest(비공개_포스트_ID, "댓글", 비공개, null);
+                댓글_작성_요청 = new WriteAuthCommentRequest(비공개_포스트_ID, 말랑_블로그_이름, "댓글", 비공개, null);
             }
 
             @Test
@@ -247,9 +248,10 @@ class CommentAcceptanceTest extends AcceptanceTest {
 
         @BeforeEach
         void setUp() {
-            동훈_댓글_ID = 댓글_작성(동훈_세션_ID, new WriteAuthCommentRequest(공개_포스트_ID, "좋은 글 감사합니다", 비공개, null), null);
+            동훈_댓글_ID = 댓글_작성(동훈_세션_ID, new WriteAuthCommentRequest(공개_포스트_ID, 말랑_블로그_이름, "좋은 글 감사합니다", 비공개, null),
+                    null);
             비인증_댓글_ID = 비인증_댓글_작성(
-                    new WriteUnAuthCommentRequest(공개_포스트_ID, "좋은 글 감사합니다", "비인증입니다", "1234", null), null);
+                    new WriteUnAuthCommentRequest(공개_포스트_ID, 말랑_블로그_이름, "좋은 글 감사합니다", "비인증입니다", "1234", null), null);
         }
 
         @Test
@@ -305,7 +307,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
 
             @BeforeEach
             void setUp() {
-                댓글_작성_요청 = new WriteAuthCommentRequest(보호_포스트_ID, "댓글", 비공개, null);
+                댓글_작성_요청 = new WriteAuthCommentRequest(보호_포스트_ID, 말랑_블로그_이름, "댓글", 비공개, null);
                 댓글_수정_요청 = new UpdateAuthCommentRequest("수정", 비공개);
             }
 
@@ -362,7 +364,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
             @Test
             void 블로그_주인은_수정_가능하다() {
                 // given
-                var 댓글_작성_요청 = new WriteAuthCommentRequest(비공개_포스트_ID, "댓글", 비공개, null);
+                var 댓글_작성_요청 = new WriteAuthCommentRequest(비공개_포스트_ID, 말랑_블로그_이름, "댓글", 비공개, null);
                 var 댓글_ID = 댓글_작성(말랑_세션_ID, 댓글_작성_요청, null);
 
                 // when
@@ -374,7 +376,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
 
             @Test
             void 블로그_주인이_아닌_경우_수정할_수_없다() {
-                var 댓글_작성_요청 = new WriteAuthCommentRequest(공개_포스트_ID, "댓글", 비공개, null);
+                var 댓글_작성_요청 = new WriteAuthCommentRequest(공개_포스트_ID, 말랑_블로그_이름, "댓글", 비공개, null);
                 var 댓글_ID = 댓글_작성(동훈_세션_ID, 댓글_작성_요청, null);
                 포스트_수정_요청(말랑_세션_ID, 공개_포스트_ID, 공개_포스트를_비공개로_바꾸는_요청);
 
@@ -395,8 +397,9 @@ class CommentAcceptanceTest extends AcceptanceTest {
 
         @BeforeEach
         void setUp() {
-            var authRequest = new WriteAuthCommentRequest(공개_포스트_ID, "좋은 글 감사합니다", 비공개, null);
-            var unAuthRequest = new WriteUnAuthCommentRequest(공개_포스트_ID, "좋은 글 감사합니다", "비인증입니다", "1234", null);
+            var authRequest = new WriteAuthCommentRequest(공개_포스트_ID, 말랑_블로그_이름, "좋은 글 감사합니다", 비공개, null);
+            var unAuthRequest = new WriteUnAuthCommentRequest(공개_포스트_ID, 말랑_블로그_이름, "좋은 글 감사합니다", "비인증입니다", "1234",
+                    null);
             동훈_댓글_ID = 댓글_작성(동훈_세션_ID, authRequest, null);
             비인증_댓글_ID = 비인증_댓글_작성(unAuthRequest, null);
         }
@@ -449,7 +452,8 @@ class CommentAcceptanceTest extends AcceptanceTest {
         @Test
         void 대댓글도_삭제가_가능하다() {
             // given
-            var 대댓글_ID = 댓글_작성(말랑_세션_ID, new WriteAuthCommentRequest(공개_포스트_ID, "대댓글입니다", 공개, 동훈_댓글_ID), null);
+            var 대댓글_ID = 댓글_작성(말랑_세션_ID, new WriteAuthCommentRequest(공개_포스트_ID, 말랑_블로그_이름, "대댓글입니다", 공개, 동훈_댓글_ID),
+                    null);
 
             // when
             var 응답 = 댓글_삭제_요청(말랑_세션_ID, 대댓글_ID, null);
@@ -463,10 +467,10 @@ class CommentAcceptanceTest extends AcceptanceTest {
             // given
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(말랑_블로그_이름));
 
-            var 댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, "좋은 글 감사합니다", "비인증", "1234", null);
+            var 댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "좋은 글 감사합니다", "비인증", "1234", null);
             var 댓글_ID = 비인증_댓글_작성(댓글_작성_요청, null);
 
-            var 대댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, "대댓글입니다", 공개, 댓글_ID);
+            var 대댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "대댓글입니다", 공개, 댓글_ID);
             var 대댓글_ID = 댓글_작성(말랑_세션_ID, 대댓글_작성_요청, null);
 
             // when
@@ -474,7 +478,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
 
             // then
             응답_상태를_검증한다(응답, 정상_처리);
-            var 댓글_조회_응답 = 특정_포스트의_댓글_전체_조회_요청(포스트_ID, null);
+            var 댓글_조회_응답 = 특정_포스트의_댓글_전체_조회_요청(포스트_ID, 말랑_블로그_이름, null);
             특정_포스트의_댓글_전체_조회_응답을_검증한다(댓글_조회_응답,
                     List.of(
                             new UnAuthCommentResponse(
@@ -499,10 +503,10 @@ class CommentAcceptanceTest extends AcceptanceTest {
         void 대댓글을_삭제하는_경우_부모_댓글이_논리적으로_제거된_상태이며_더이상_존재하는_자식이_없는_경우_부모_댓글도_물리적으로_제거된다() {
             // given
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(말랑_블로그_이름));
-            var 댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, "좋은 글 감사합니다", "비인증", "1234", null);
+            var 댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "좋은 글 감사합니다", "비인증", "1234", null);
             var 댓글_ID = 비인증_댓글_작성(댓글_작성_요청, null);
 
-            var 대댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, "대댓글입니다", 공개, 댓글_ID);
+            var 대댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "대댓글입니다", 공개, 댓글_ID);
             var 대댓글_ID = 댓글_작성(말랑_세션_ID, 대댓글_작성_요청, null);
             비인증_댓글_삭제_요청(댓글_ID, "1234", null);
 
@@ -511,7 +515,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
 
             // then
             응답_상태를_검증한다(응답, 정상_처리);
-            var 댓글_조회_응답 = 특정_포스트의_댓글_전체_조회_요청(포스트_ID, null);
+            var 댓글_조회_응답 = 특정_포스트의_댓글_전체_조회_요청(포스트_ID, 말랑_블로그_이름, null);
             특정_포스트의_댓글_전체_조회_응답을_검증한다(댓글_조회_응답, emptyList());
         }
 
@@ -524,7 +528,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
                 @Test
                 void 삭제_가능하다() {
                     // given
-                    var 댓글_작성_요청 = new WriteAuthCommentRequest(보호_포스트_ID, "댓글", 비공개, null);
+                    var 댓글_작성_요청 = new WriteAuthCommentRequest(보호_포스트_ID, 말랑_블로그_이름, "댓글", 비공개, null);
                     var 댓글_ID = 댓글_작성(말랑_세션_ID, 댓글_작성_요청, null);
 
                     // when
@@ -541,7 +545,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
                 @Test
                 void 입력한_비밀번호가_포스트의_비밀번호와_다르다면_삭제할_수_없다() {
                     // given
-                    var 댓글_작성_요청 = new WriteAuthCommentRequest(보호_포스트_ID, "댓글", 비공개, null);
+                    var 댓글_작성_요청 = new WriteAuthCommentRequest(보호_포스트_ID, 말랑_블로그_이름, "댓글", 비공개, null);
                     var 댓글_ID = 댓글_작성(동훈_세션_ID, 댓글_작성_요청, "1234");
 
                     // when
@@ -554,7 +558,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
                 @Test
                 void 입력한_비밀번호가_포스트의_비밀번호와_일치하면_삭제할_수_있다() {
                     // given
-                    var 댓글_작성_요청 = new WriteAuthCommentRequest(보호_포스트_ID, "댓글", 비공개, null);
+                    var 댓글_작성_요청 = new WriteAuthCommentRequest(보호_포스트_ID, 말랑_블로그_이름, "댓글", 비공개, null);
                     var 댓글_ID = 댓글_작성(동훈_세션_ID, 댓글_작성_요청, "1234");
 
                     // when
@@ -572,7 +576,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
             @Test
             void 블로그_주인은_삭제_가능하다() {
                 // given
-                var 댓글_작성_요청 = new WriteAuthCommentRequest(비공개_포스트_ID, "댓글", 비공개, null);
+                var 댓글_작성_요청 = new WriteAuthCommentRequest(비공개_포스트_ID, 말랑_블로그_이름, "댓글", 비공개, null);
                 var 댓글_ID = 댓글_작성(말랑_세션_ID, 댓글_작성_요청, null);
 
                 // when
@@ -584,7 +588,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
 
             @Test
             void 블로그_주인이_아닌_경우_삭제할_수_없다() {
-                var 댓글_작성_요청 = new WriteAuthCommentRequest(공개_포스트_ID, "댓글", 비공개, null);
+                var 댓글_작성_요청 = new WriteAuthCommentRequest(공개_포스트_ID, 말랑_블로그_이름, "댓글", 비공개, null);
                 var 댓글_ID = 댓글_작성(동훈_세션_ID, 댓글_작성_요청, null);
                 포스트_수정_요청(말랑_세션_ID, 공개_포스트_ID, 공개_포스트를_비공개로_바꾸는_요청);
 
@@ -611,16 +615,16 @@ class CommentAcceptanceTest extends AcceptanceTest {
         void 로그인하지_않은_경우_비밀_댓글은_비밀_댓글입니다로_처리되어_조회된다() {
             // given
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(말랑_블로그_이름));
-            var 헤헤_댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, "헤헤 댓글", "헤헤", "1234", null);
-            var 동훈_공개_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, "동훈 댓글", 공개, null);
-            var 동훈_비밀_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, "[비밀] 동훈 댓글", 비공개, null);
+            var 헤헤_댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "헤헤 댓글", "헤헤", "1234", null);
+            var 동훈_공개_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "동훈 댓글", 공개, null);
+            var 동훈_비밀_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "[비밀] 동훈 댓글", 비공개, null);
 
             var 헤헤_댓글_ID = 비인증_댓글_작성(헤헤_댓글_작성_요청, null);
             var 동훈_공개_댓글_ID = 댓글_작성(동훈_세션_ID, 동훈_공개_댓글_작성_요청, null);
             var 동훈_비밀_댓글_ID = 댓글_작성(동훈_세션_ID, 동훈_비밀_댓글_작성_요청, null);
 
             // when
-            var 응답 = 특정_포스트의_댓글_전체_조회_요청(포스트_ID, null);
+            var 응답 = 특정_포스트의_댓글_전체_조회_요청(포스트_ID, 말랑_블로그_이름, null);
 
             // then
             var 예상_데이터 = List.of(
@@ -655,11 +659,11 @@ class CommentAcceptanceTest extends AcceptanceTest {
         void 로그인한_경우_내가_쓴_비밀_댓글을_포함한_댓글들이_전체_조회된다() {
             // given
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(말랑_블로그_이름));
-            var 헤헤_댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, "헤헤 댓글", "헤헤", "1234", null);
-            var 동훈_공개_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, "동훈 댓글", 공개, null);
-            var 동훈_비밀_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, "[비밀] 동훈 댓글", 비공개, null);
-            var 후후_공개_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, "후후 댓글", 공개, null);
-            var 후후_비밀_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, "[비밀] 후후 댓글", 비공개, null);
+            var 헤헤_댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "헤헤 댓글", "헤헤", "1234", null);
+            var 동훈_공개_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "동훈 댓글", 공개, null);
+            var 동훈_비밀_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "[비밀] 동훈 댓글", 비공개, null);
+            var 후후_공개_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "후후 댓글", 공개, null);
+            var 후후_비밀_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "[비밀] 후후 댓글", 비공개, null);
 
             var 헤헤_댓글_ID = 비인증_댓글_작성(헤헤_댓글_작성_요청, null);
             var 동훈_공개_댓글_ID = 댓글_작성(동훈_세션_ID, 동훈_공개_댓글_작성_요청, null);
@@ -668,7 +672,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
             var 후후_비밀_댓글_ID = 댓글_작성(후후_세션_ID, 후후_비밀_댓글_작성_요청, null);
 
             // when
-            var 응답 = 특정_포스트의_댓글_전체_조회_요청(동훈_세션_ID, 포스트_ID, null);
+            var 응답 = 특정_포스트의_댓글_전체_조회_요청(동훈_세션_ID, 포스트_ID, 말랑_블로그_이름, null);
 
             // then
             var 예상_데이터 = List.of(
@@ -726,19 +730,19 @@ class CommentAcceptanceTest extends AcceptanceTest {
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(말랑_블로그_이름));
             var 헤나_세션_ID = 회원가입과_로그인_후_세션_ID_반환("헤나");
 
-            var 동훈_댓글_요청 = new WriteAuthCommentRequest(포스트_ID, "[비밀] 동훈 댓글", 비공개, null);
+            var 동훈_댓글_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "[비밀] 동훈 댓글", 비공개, null);
             var 동훈_비공개_댓글_ID = 댓글_작성(동훈_세션_ID, 동훈_댓글_요청, null);
 
-            var 헤나_댓글_요청 = new WriteAuthCommentRequest(포스트_ID, "[비밀] 헤나 댓글", 비공개, 동훈_비공개_댓글_ID);
-            var 후후_댓글_요청 = new WriteAuthCommentRequest(포스트_ID, "[비밀] 후후 댓글", 비공개, 동훈_비공개_댓글_ID);
+            var 헤나_댓글_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "[비밀] 헤나 댓글", 비공개, 동훈_비공개_댓글_ID);
+            var 후후_댓글_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "[비밀] 후후 댓글", 비공개, 동훈_비공개_댓글_ID);
 
             var 헤나_비밀_댓글_ID = 댓글_작성(헤나_세션_ID, 헤나_댓글_요청, null);
             var 후후_비밀_댓글_ID = 댓글_작성(후후_세션_ID, 후후_댓글_요청, null);
 
             // when
-            var 댓글_작성자_조회_결과 = 특정_포스트의_댓글_전체_조회_요청(동훈_세션_ID, 포스트_ID, null);
-            var 대댓글_작성자_조회_결과1 = 특정_포스트의_댓글_전체_조회_요청(헤나_세션_ID, 포스트_ID, null);
-            var 대댓글_작성자_조회_결과2 = 특정_포스트의_댓글_전체_조회_요청(후후_세션_ID, 포스트_ID, null);
+            var 댓글_작성자_조회_결과 = 특정_포스트의_댓글_전체_조회_요청(동훈_세션_ID, 포스트_ID, 말랑_블로그_이름, null);
+            var 대댓글_작성자_조회_결과1 = 특정_포스트의_댓글_전체_조회_요청(헤나_세션_ID, 포스트_ID, 말랑_블로그_이름, null);
+            var 대댓글_작성자_조회_결과2 = 특정_포스트의_댓글_전체_조회_요청(후후_세션_ID, 포스트_ID, 말랑_블로그_이름, null);
 
             // then
             var 댓글_작성자_예상_데이터 = List.of(
@@ -834,21 +838,21 @@ class CommentAcceptanceTest extends AcceptanceTest {
             // given
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(말랑_블로그_이름));
 
-            var 헤헤_댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, "헤헤 댓글", "헤헤", "1234", null);
+            var 헤헤_댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "헤헤 댓글", "헤헤", "1234", null);
             var 헤헤_댓글_ID = 비인증_댓글_작성(헤헤_댓글_작성_요청, null);
 
-            var 동훈_공개_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, "동훈 댓글", 공개, null);
-            var 동훈_비밀_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, "[비밀] 동훈 댓글", 비공개, null);
+            var 동훈_공개_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "동훈 댓글", 공개, null);
+            var 동훈_비밀_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "[비밀] 동훈 댓글", 비공개, null);
             var 동훈_공개_댓글_ID = 댓글_작성(동훈_세션_ID, 동훈_공개_댓글_작성_요청, null);
             var 동훈_비밀_댓글_ID = 댓글_작성(동훈_세션_ID, 동훈_비밀_댓글_작성_요청, null);
 
-            var 후후공개_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, "후후 댓글", 공개, null);
-            var 후후_비밀_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, "[비밀] 후후 댓글", 비공개, null);
+            var 후후공개_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "후후 댓글", 공개, null);
+            var 후후_비밀_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "[비밀] 후후 댓글", 비공개, null);
             var 후후_공개_댓글_ID = 댓글_작성(후후_세션_ID, 후후공개_댓글_작성_요청, null);
             var 후후_비밀_댓글_ID = 댓글_작성(후후_세션_ID, 후후_비밀_댓글_작성_요청, null);
 
             // when
-            var 응답 = 특정_포스트의_댓글_전체_조회_요청(말랑_세션_ID, 포스트_ID, null);
+            var 응답 = 특정_포스트의_댓글_전체_조회_요청(말랑_세션_ID, 포스트_ID, 말랑_블로그_이름, null);
 
             // then
             var 예상_데이터 = List.of(
@@ -904,9 +908,9 @@ class CommentAcceptanceTest extends AcceptanceTest {
         void 삭제된_댓글은_삭제된_댓글입니다로_처리되어_조회된다() {
             // given
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(말랑_블로그_이름));
-            var 댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, "좋은 글 감사합니다", "비인증 말랑", "1234", null);
+            var 댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "좋은 글 감사합니다", "비인증 말랑", "1234", null);
             var 댓글_ID = 비인증_댓글_작성(댓글_작성_요청, null);
-            var 대댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, "대댓글입니다", 공개, 댓글_ID);
+            var 대댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "대댓글입니다", 공개, 댓글_ID);
             var 대댓글_ID = 댓글_작성(말랑_세션_ID, 대댓글_작성_요청, null);
             비인증_댓글_삭제_요청(댓글_ID, "1234", null);
 
@@ -915,7 +919,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
 
             // then
             응답_상태를_검증한다(응답, 정상_처리);
-            var 댓글_조회_응답 = 특정_포스트의_댓글_전체_조회_요청(포스트_ID, null);
+            var 댓글_조회_응답 = 특정_포스트의_댓글_전체_조회_요청(포스트_ID, 말랑_블로그_이름, null);
             특정_포스트의_댓글_전체_조회_응답을_검증한다(댓글_조회_응답,
                     List.of(
                             new UnAuthCommentResponse(
@@ -946,14 +950,14 @@ class CommentAcceptanceTest extends AcceptanceTest {
                 void 조회_가능하다() {
                     // given
                     var 포스트_ID = 포스트_생성(말랑_세션_ID, 보호_포스트_생성_데이터(말랑_블로그_이름));
-                    var 댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, "비인증 댓글", "비인증", "1234", null);
+                    var 댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "비인증 댓글", "비인증", "1234", null);
                     var 비인증_댓글_ID = 비인증_댓글_작성(댓글_작성_요청, "1234");
 
-                    var 동훈_비밀_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, "[비밀] 동훈 댓글", 비공개, null);
+                    var 동훈_비밀_댓글_작성_요청 = new WriteAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "[비밀] 동훈 댓글", 비공개, null);
                     var 동훈_비밀_댓글_ID = 댓글_작성(동훈_세션_ID, 동훈_비밀_댓글_작성_요청, "1234");
 
                     // when
-                    var 응답 = 특정_포스트의_댓글_전체_조회_요청(말랑_세션_ID, 포스트_ID, null);
+                    var 응답 = 특정_포스트의_댓글_전체_조회_요청(말랑_세션_ID, 포스트_ID, 말랑_블로그_이름, null);
 
                     // then
                     var 예상_데이터 = List.of(
@@ -986,11 +990,11 @@ class CommentAcceptanceTest extends AcceptanceTest {
                 void 입력한_비밀번호가_포스트의_비밀번호와_다르다면_조회할_수_없다() {
                     // given
                     var 포스트_ID = 포스트_생성(말랑_세션_ID, 보호_포스트_생성_데이터(말랑_블로그_이름));
-                    var 댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, "비인증 댓글", "비인증", "1234", null);
+                    var 댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "비인증 댓글", "비인증", "1234", null);
                     var 비인증_댓글_ID = 비인증_댓글_작성(댓글_작성_요청, "1234");
 
                     // when
-                    var 응답 = 특정_포스트의_댓글_전체_조회_요청(동훈_세션_ID, 포스트_ID, null);
+                    var 응답 = 특정_포스트의_댓글_전체_조회_요청(동훈_세션_ID, 포스트_ID, 말랑_블로그_이름, null);
 
                     // then
                     응답_상태를_검증한다(응답, 권한_없음);
@@ -1000,11 +1004,11 @@ class CommentAcceptanceTest extends AcceptanceTest {
                 void 입력한_비밀번호가_포스트의_비밀번호와_일치하면_조회할_수_있다() {
                     // given
                     var 포스트_ID = 포스트_생성(말랑_세션_ID, 보호_포스트_생성_데이터(말랑_블로그_이름));
-                    var 댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, "비인증 댓글", "비인증", "1234", null);
+                    var 댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "비인증 댓글", "비인증", "1234", null);
                     var 비인증_댓글_ID = 비인증_댓글_작성(댓글_작성_요청, "1234");
 
                     // when
-                    var 응답 = 특정_포스트의_댓글_전체_조회_요청(동훈_세션_ID, 포스트_ID, "1234");
+                    var 응답 = 특정_포스트의_댓글_전체_조회_요청(동훈_세션_ID, 포스트_ID, 말랑_블로그_이름, "1234");
 
                     // then
                     var 예상_데이터 = List.of(
@@ -1029,12 +1033,12 @@ class CommentAcceptanceTest extends AcceptanceTest {
             void 블로그_주인은_조회_가능하다() {
                 // given
                 var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(말랑_블로그_이름));
-                var 비인증_댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, "비인증 댓글", "헤헤", "1234", null);
+                var 비인증_댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "비인증 댓글", "헤헤", "1234", null);
                 var 비인증_댓글_ID = 비인증_댓글_작성(비인증_댓글_작성_요청, null);
                 포스트_수정_요청(말랑_세션_ID, 포스트_ID, 공개_포스트를_비공개로_바꾸는_요청);
 
                 // when
-                var 응답 = 특정_포스트의_댓글_전체_조회_요청(말랑_세션_ID, 포스트_ID, null);
+                var 응답 = 특정_포스트의_댓글_전체_조회_요청(말랑_세션_ID, 포스트_ID, 말랑_블로그_이름, null);
 
                 // then
                 var 예상_데이터 = List.of(
@@ -1053,12 +1057,12 @@ class CommentAcceptanceTest extends AcceptanceTest {
             @Test
             void 블로그_주인이_아닌_경우_조회할_수_없다() {
                 var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(말랑_블로그_이름));
-                var 비인증_댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, "비인증 댓글", "헤헤", "1234", null);
+                var 비인증_댓글_작성_요청 = new WriteUnAuthCommentRequest(포스트_ID, 말랑_블로그_이름, "비인증 댓글", "헤헤", "1234", null);
                 var 비인증_댓글_ID = 비인증_댓글_작성(비인증_댓글_작성_요청, null);
                 포스트_수정_요청(말랑_세션_ID, 포스트_ID, 공개_포스트를_비공개로_바꾸는_요청);
 
                 // when
-                var 응답 = 특정_포스트의_댓글_전체_조회_요청(포스트_작성자가_아닌_다른_회원_세션_ID, 포스트_ID, null);
+                var 응답 = 특정_포스트의_댓글_전체_조회_요청(포스트_작성자가_아닌_다른_회원_세션_ID, 포스트_ID, 말랑_블로그_이름, null);
 
                 // then
                 응답_상태를_검증한다(응답, 권한_없음);

--- a/src/test/java/com/mallang/acceptance/post/PostAcceptanceSteps.java
+++ b/src/test/java/com/mallang/acceptance/post/PostAcceptanceSteps.java
@@ -24,11 +24,12 @@ public class PostAcceptanceSteps {
     public static ExtractableResponse<Response> 포스트_단일_조회_요청(
             @Nullable String 세션_ID,
             Long 포스트_ID,
+            String 블로그_이름,
             @Nullable String 비밀번호
     ) {
         return given(세션_ID)
                 .cookie(POST_PASSWORD_COOKIE, 비밀번호)
-                .get("/posts/{id}", 포스트_ID)
+                .get("/posts/{blogName}/{id}", 블로그_이름, 포스트_ID)
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/com/mallang/acceptance/post/PostAcceptanceTest.java
+++ b/src/test/java/com/mallang/acceptance/post/PostAcceptanceTest.java
@@ -13,9 +13,9 @@ import static com.mallang.acceptance.post.PostAcceptanceSteps.포스트_전체_�
 import static com.mallang.acceptance.post.PostAcceptanceSteps.포스트_전체_조회_응답을_검증한다;
 import static com.mallang.acceptance.post.PostLikeAcceptanceSteps.포스트_좋아요_요청;
 import static com.mallang.acceptance.post.PostManageAcceptanceSteps.포스트_생성;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PROTECTED;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PUBLIC;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PROTECTED;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PUBLIC;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -110,7 +110,7 @@ class PostAcceptanceTest extends AcceptanceTest {
         @Test
         void 포스트를_단일_조회한다() {
             // when
-            var 응답 = 포스트_단일_조회_요청(null, 공개_포스트_ID, null);
+            var 응답 = 포스트_단일_조회_요청(null, 공개_포스트_ID, 말랑_블로그_이름, null);
 
             // then
             PostDetailResponse postDetailResponse = 응답.as(PostDetailResponse.class);
@@ -123,7 +123,7 @@ class PostAcceptanceTest extends AcceptanceTest {
             var 없는_ID = 100L;
 
             // when
-            var 응답 = 포스트_단일_조회_요청(null, 없는_ID, null);
+            var 응답 = 포스트_단일_조회_요청(null, 없는_ID, 말랑_블로그_이름, null);
 
             // then
             응답_상태를_검증한다(응답, 찾을수_없음);
@@ -132,11 +132,11 @@ class PostAcceptanceTest extends AcceptanceTest {
         @Test
         void 좋아요_눌렀는지_여부가_반영된다() {
             // given
-            포스트_좋아요_요청(말랑_세션_ID, 공개_포스트_ID, null);
+            포스트_좋아요_요청(말랑_세션_ID, 공개_포스트_ID, 말랑_블로그_이름, null);
 
             // when
-            var 좋아요_눌린_응답 = 포스트_단일_조회_요청(말랑_세션_ID, 공개_포스트_ID, null);
-            var 좋아요_안눌린_응답 = 포스트_단일_조회_요청(null, 공개_포스트_ID, null);
+            var 좋아요_눌린_응답 = 포스트_단일_조회_요청(말랑_세션_ID, 공개_포스트_ID, 말랑_블로그_이름, null);
+            var 좋아요_안눌린_응답 = 포스트_단일_조회_요청(null, 공개_포스트_ID, 말랑_블로그_이름, null);
 
             // then
             assertThat(좋아요_눌린_응답.as(PostDetailResponse.class).isLiked()).isTrue();
@@ -146,7 +146,7 @@ class PostAcceptanceTest extends AcceptanceTest {
         @Test
         void 블로그_주인은_비공개_글을_볼_수_있다() {
             // when
-            var 응답 = 포스트_단일_조회_요청(말랑_세션_ID, 비공개_포스트_ID, null);
+            var 응답 = 포스트_단일_조회_요청(말랑_세션_ID, 비공개_포스트_ID, 말랑_블로그_이름, null);
 
             // then
             PostDetailResponse postDetailResponse = 응답.as(PostDetailResponse.class);
@@ -157,7 +157,7 @@ class PostAcceptanceTest extends AcceptanceTest {
         @Test
         void 블로그_주인이_아니라면_비공개_글_조회시_예외() {
             // when
-            var 응답 = 포스트_단일_조회_요청(null, 비공개_포스트_ID, null);
+            var 응답 = 포스트_단일_조회_요청(null, 비공개_포스트_ID, 말랑_블로그_이름, null);
 
             // then
             응답_상태를_검증한다(응답, 권한_없음);
@@ -166,7 +166,7 @@ class PostAcceptanceTest extends AcceptanceTest {
         @Test
         void 블로그_주인은_보호글을_볼_수_있다() {
             // when
-            var 응답 = 포스트_단일_조회_요청(말랑_세션_ID, 보호_포스트_ID, null);
+            var 응답 = 포스트_단일_조회_요청(말랑_세션_ID, 보호_포스트_ID, 말랑_블로그_이름, null);
 
             // then
             PostDetailResponse postDetailResponse = 응답.as(PostDetailResponse.class);
@@ -179,12 +179,13 @@ class PostAcceptanceTest extends AcceptanceTest {
         @Test
         void 블로그_주인이_아닌_경우_보호글_조회시_내용과_썸네일_이미지가_보호된다() {
             // when
-            var 응답 = 포스트_단일_조회_요청(null, 보호_포스트_ID, null);
+            var 응답 = 포스트_단일_조회_요청(null, 보호_포스트_ID, 말랑_블로그_이름, null);
 
             // then
             포스트_단일_조회_응답을_검증한다(응답,
                     new PostDetailResponse(
                             보호_포스트_ID,
+                            말랑_블로그_이름,
                             "[보호] 제목",
                             "보호되어 있는 글입니다. 내용을 보시려면 비밀번호를 입력하세요.",
                             "",
@@ -328,6 +329,7 @@ class PostAcceptanceTest extends AcceptanceTest {
             var 예상_데이터 = List.of(
                     new PostSearchResponse(
                             동훈_비공개_포스트_ID,
+                            동훈_블로그_이름,
                             "[비공개] 동훈 제목",
                             "[비공개] 동훈 내용",
                             "[비공개] 동훈 인트로",
@@ -341,6 +343,7 @@ class PostAcceptanceTest extends AcceptanceTest {
                     ),
                     new PostSearchResponse(
                             동훈_보호_포스트_ID,
+                            동훈_블로그_이름,
                             "[보호] 동훈 제목",
                             "[보호] 동훈 내용",
                             "[보호] 동훈 인트로",
@@ -354,6 +357,7 @@ class PostAcceptanceTest extends AcceptanceTest {
                     ),
                     new PostSearchResponse(
                             동훈_공개_포스트_ID,
+                            동훈_블로그_이름,
                             "[공개] 동훈 제목",
                             "[공개] 동훈 내용",
                             "[공개] 동훈 인트로",
@@ -368,6 +372,7 @@ class PostAcceptanceTest extends AcceptanceTest {
 
                     new PostSearchResponse(
                             말랑_보호_포스트_ID,
+                            말랑_블로그_이름,
                             "[보호] 말랑 제목",
                             "보호되어 있는 글입니다.",
                             "",
@@ -381,6 +386,7 @@ class PostAcceptanceTest extends AcceptanceTest {
                     ),
                     new PostSearchResponse(
                             말랑_공개_포스트_ID,
+                            말랑_블로그_이름,
                             "[공개] 말랑 제목",
                             "[공개] 말랑 내용",
                             "[공개] 말랑 인트로",
@@ -587,6 +593,7 @@ class PostAcceptanceTest extends AcceptanceTest {
             var 예상 = List.of(
                     new PostSearchResponse(
                             포스트1_ID,
+                            말랑_블로그_이름,
                             "포스트",
                             "보호된 글입니다.",
                             "",

--- a/src/test/java/com/mallang/acceptance/post/PostLikeAcceptanceSteps.java
+++ b/src/test/java/com/mallang/acceptance/post/PostLikeAcceptanceSteps.java
@@ -12,19 +12,29 @@ import jakarta.annotation.Nullable;
 @SuppressWarnings("NonAsciiCharacters")
 public class PostLikeAcceptanceSteps {
 
-    public static ExtractableResponse<Response> 포스트_좋아요_요청(String 세션_ID, Long 포스트_ID, @Nullable String 비밀번호) {
+    public static ExtractableResponse<Response> 포스트_좋아요_요청(
+            String 세션_ID,
+            Long 포스트_ID,
+            String 블로그_이름,
+            @Nullable String 비밀번호
+    ) {
         return given(세션_ID)
                 .cookie(POST_PASSWORD_COOKIE, 비밀번호)
-                .body(new ClickPostLikeRequest(포스트_ID))
+                .body(new ClickPostLikeRequest(포스트_ID, 블로그_이름))
                 .post("/post-likes")
                 .then().log().all()
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 좋아요_취소_요청(String 세션_ID, Long 포스트_ID, @Nullable String 비밀번호) {
+    public static ExtractableResponse<Response> 좋아요_취소_요청(
+            String 세션_ID,
+            Long 포스트_ID,
+            String 블로그_이름,
+            @Nullable String 비밀번호
+    ) {
         return given(세션_ID)
                 .cookie(POST_PASSWORD_COOKIE, 비밀번호)
-                .body(new CancelPostLikeRequest(포스트_ID))
+                .body(new CancelPostLikeRequest(포스트_ID, 블로그_이름))
                 .delete("/post-likes")
                 .then().log().all()
                 .extract();

--- a/src/test/java/com/mallang/acceptance/post/PostLikeAcceptanceTest.java
+++ b/src/test/java/com/mallang/acceptance/post/PostLikeAcceptanceTest.java
@@ -17,8 +17,8 @@ import static com.mallang.acceptance.post.PostManageAcceptanceSteps.보호_포�
 import static com.mallang.acceptance.post.PostManageAcceptanceSteps.비공개_포스트_생성_데이터;
 import static com.mallang.acceptance.post.PostManageAcceptanceSteps.포스트_생성;
 import static com.mallang.acceptance.post.PostManageAcceptanceSteps.포스트_수정_요청;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PROTECTED;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PROTECTED;
 import static java.util.Collections.emptyList;
 
 import com.mallang.acceptance.AcceptanceTest;
@@ -47,6 +47,7 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
         말랑_세션_ID = 회원가입과_로그인_후_세션_ID_반환("말랑");
         블로그_이름 = 블로그_개설(말랑_세션_ID, "mallang-log");
         공개_포스트를_보호로_바꾸는_요청 = new UpdatePostRequest(
+                블로그_이름,
                 "보호로 변경",
                 "보호",
                 null,
@@ -57,6 +58,7 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
                 emptyList()
         );
         공개_포스트를_비공개로_바꾸는_요청 = new UpdatePostRequest(
+                블로그_이름,
                 "보호로 변경",
                 "보호",
                 null,
@@ -77,7 +79,7 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(블로그_이름));
 
             // when
-            var 응답 = 포스트_좋아요_요청(없음(), 포스트_ID, null);
+            var 응답 = 포스트_좋아요_요청(없음(), 포스트_ID, 블로그_이름, null);
 
             // then
             응답_상태를_검증한다(응답, 인증되지_않음);
@@ -89,7 +91,7 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
             var 동훈_세션_ID = 회원가입과_로그인_후_세션_ID_반환("동훈");
 
             // when
-            var 응답 = 포스트_좋아요_요청(동훈_세션_ID, 포스트_ID, null);
+            var 응답 = 포스트_좋아요_요청(동훈_세션_ID, 포스트_ID, 블로그_이름, null);
 
             // then
             응답_상태를_검증한다(응답, 생성됨);
@@ -99,10 +101,10 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
         void 이미_좋아요를_누른_포스트에는_중복해서_좋아요를_누를_수_없다() {
             // given
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(블로그_이름));
-            포스트_좋아요_요청(말랑_세션_ID, 포스트_ID, null);
+            포스트_좋아요_요청(말랑_세션_ID, 포스트_ID, 블로그_이름, null);
 
             // when
-            var 응답 = 포스트_좋아요_요청(말랑_세션_ID, 포스트_ID, null);
+            var 응답 = 포스트_좋아요_요청(말랑_세션_ID, 포스트_ID, 블로그_이름, null);
 
             // then
             응답_상태를_검증한다(응답, 중복됨);
@@ -120,7 +122,7 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
                     var 포스트_ID = 포스트_생성(말랑_세션_ID, 보호_포스트_생성_데이터(블로그_이름));
 
                     // when
-                    var 응답 = 포스트_좋아요_요청(말랑_세션_ID, 포스트_ID, null);
+                    var 응답 = 포스트_좋아요_요청(말랑_세션_ID, 포스트_ID, 블로그_이름, null);
 
                     // then
                     응답_상태를_검증한다(응답, 생성됨);
@@ -137,7 +139,7 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
                     var 동훈_세션_ID = 회원가입과_로그인_후_세션_ID_반환("동훈");
 
                     // when
-                    var 응답 = 포스트_좋아요_요청(동훈_세션_ID, 포스트_ID, null);
+                    var 응답 = 포스트_좋아요_요청(동훈_세션_ID, 포스트_ID, 블로그_이름, null);
 
                     // then
                     응답_상태를_검증한다(응답, 권한_없음);
@@ -150,7 +152,7 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
                     var 동훈_세션_ID = 회원가입과_로그인_후_세션_ID_반환("동훈");
 
                     // when
-                    var 응답 = 포스트_좋아요_요청(동훈_세션_ID, 포스트_ID, "1234");
+                    var 응답 = 포스트_좋아요_요청(동훈_세션_ID, 포스트_ID, 블로그_이름, "1234");
 
                     // then
                     응답_상태를_검증한다(응답, 생성됨);
@@ -167,7 +169,7 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
                 var 포스트_ID = 포스트_생성(말랑_세션_ID, 비공개_포스트_생성_데이터(블로그_이름));
 
                 // when
-                var 응답 = 포스트_좋아요_요청(말랑_세션_ID, 포스트_ID, null);
+                var 응답 = 포스트_좋아요_요청(말랑_세션_ID, 포스트_ID, 블로그_이름, null);
 
                 // then
                 응답_상태를_검증한다(응답, 생성됨);
@@ -180,7 +182,7 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
                 var 동훈_세션_ID = 회원가입과_로그인_후_세션_ID_반환("동훈");
 
                 // when
-                var 응답 = 포스트_좋아요_요청(동훈_세션_ID, 포스트_ID, null);
+                var 응답 = 포스트_좋아요_요청(동훈_세션_ID, 포스트_ID, 블로그_이름, null);
 
                 // then
                 응답_상태를_검증한다(응답, 권한_없음);
@@ -195,10 +197,10 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
         void 좋아요를_취소한다() {
             // given
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(블로그_이름));
-            포스트_좋아요_요청(말랑_세션_ID, 포스트_ID, null);
+            포스트_좋아요_요청(말랑_세션_ID, 포스트_ID, 블로그_이름, null);
 
             // when
-            var 응답 = 좋아요_취소_요청(말랑_세션_ID, 포스트_ID, null);
+            var 응답 = 좋아요_취소_요청(말랑_세션_ID, 포스트_ID, 블로그_이름, null);
 
             // then
             응답_상태를_검증한다(응답, 본문_없음);
@@ -210,7 +212,7 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(블로그_이름));
 
             // when
-            var 응답 = 좋아요_취소_요청(말랑_세션_ID, 포스트_ID, null);
+            var 응답 = 좋아요_취소_요청(말랑_세션_ID, 포스트_ID, 블로그_이름, null);
 
             // then
             응답_상태를_검증한다(응답, 찾을수_없음);
@@ -226,10 +228,10 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
                 void 좋아요를_취소할_수_있다() {
                     // given
                     var 포스트_ID = 포스트_생성(말랑_세션_ID, 보호_포스트_생성_데이터(블로그_이름));
-                    포스트_좋아요_요청(말랑_세션_ID, 포스트_ID, null);
+                    포스트_좋아요_요청(말랑_세션_ID, 포스트_ID, 블로그_이름, null);
 
                     // when
-                    var 응답 = 좋아요_취소_요청(말랑_세션_ID, 포스트_ID, null);
+                    var 응답 = 좋아요_취소_요청(말랑_세션_ID, 포스트_ID, 블로그_이름, null);
 
                     // then
                     응답_상태를_검증한다(응답, 본문_없음);
@@ -244,11 +246,11 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
                     // given
                     var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(블로그_이름));
                     var 동훈_세션_ID = 회원가입과_로그인_후_세션_ID_반환("동훈");
-                    포스트_좋아요_요청(동훈_세션_ID, 포스트_ID, null);
+                    포스트_좋아요_요청(동훈_세션_ID, 포스트_ID, 블로그_이름, null);
                     포스트_수정_요청(말랑_세션_ID, 포스트_ID, 공개_포스트를_비공개로_바꾸는_요청);
 
                     // when
-                    var 응답 = 좋아요_취소_요청(동훈_세션_ID, 포스트_ID, null);
+                    var 응답 = 좋아요_취소_요청(동훈_세션_ID, 포스트_ID, 블로그_이름, null);
 
                     // then
                     응답_상태를_검증한다(응답, 권한_없음);
@@ -259,11 +261,11 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
                     // given
                     var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(블로그_이름));
                     var 동훈_세션_ID = 회원가입과_로그인_후_세션_ID_반환("동훈");
-                    포스트_좋아요_요청(동훈_세션_ID, 포스트_ID, null);
+                    포스트_좋아요_요청(동훈_세션_ID, 포스트_ID, 블로그_이름, null);
                     포스트_수정_요청(말랑_세션_ID, 포스트_ID, 공개_포스트를_보호로_바꾸는_요청);
 
                     // when
-                    var 응답 = 좋아요_취소_요청(동훈_세션_ID, 포스트_ID, "1234");
+                    var 응답 = 좋아요_취소_요청(동훈_세션_ID, 포스트_ID, 블로그_이름, "1234");
 
                     // then
                     응답_상태를_검증한다(응답, 본문_없음);
@@ -278,10 +280,10 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
             void 블로그_주인은_취소할_수_있다() {
                 // given
                 var 포스트_ID = 포스트_생성(말랑_세션_ID, 비공개_포스트_생성_데이터(블로그_이름));
-                포스트_좋아요_요청(말랑_세션_ID, 포스트_ID, null);
+                포스트_좋아요_요청(말랑_세션_ID, 포스트_ID, 블로그_이름, null);
 
                 // when
-                var 응답 = 좋아요_취소_요청(말랑_세션_ID, 포스트_ID, null);
+                var 응답 = 좋아요_취소_요청(말랑_세션_ID, 포스트_ID, 블로그_이름, null);
 
                 // then
                 응답_상태를_검증한다(응답, 본문_없음);
@@ -292,11 +294,11 @@ class PostLikeAcceptanceTest extends AcceptanceTest {
                 // given
                 var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(블로그_이름));
                 var 동훈_세션_ID = 회원가입과_로그인_후_세션_ID_반환("동훈");
-                포스트_좋아요_요청(동훈_세션_ID, 포스트_ID, null);
+                포스트_좋아요_요청(동훈_세션_ID, 포스트_ID, 블로그_이름, null);
                 포스트_수정_요청(말랑_세션_ID, 포스트_ID, 공개_포스트를_비공개로_바꾸는_요청);
 
                 // when
-                var 응답 = 좋아요_취소_요청(동훈_세션_ID, 포스트_ID, null);
+                var 응답 = 좋아요_취소_요청(동훈_세션_ID, 포스트_ID, 블로그_이름, null);
 
                 // then
                 응답_상태를_검증한다(응답, 권한_없음);

--- a/src/test/java/com/mallang/acceptance/post/PostManageAcceptanceSteps.java
+++ b/src/test/java/com/mallang/acceptance/post/PostManageAcceptanceSteps.java
@@ -3,13 +3,13 @@ package com.mallang.acceptance.post;
 import static com.mallang.acceptance.AcceptanceSteps.ID를_추출한다;
 import static com.mallang.acceptance.AcceptanceSteps.given;
 import static com.mallang.acceptance.AcceptanceSteps.없음;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PROTECTED;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PUBLIC;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PROTECTED;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PUBLIC;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mallang.common.presentation.PageResponse;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import com.mallang.post.presentation.request.CreatePostRequest;
 import com.mallang.post.presentation.request.DeletePostRequest;
 import com.mallang.post.presentation.request.UpdatePostRequest;
@@ -95,9 +95,9 @@ public class PostManageAcceptanceSteps {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 포스트_삭제_요청(String 말랑_세션_ID, Long 포스트_ID) {
+    public static ExtractableResponse<Response> 포스트_삭제_요청(String 말랑_세션_ID, Long 포스트_ID, String 블로그_이름) {
         return given(말랑_세션_ID)
-                .body(new DeletePostRequest(Arrays.asList(포스트_ID)))
+                .body(new DeletePostRequest(Arrays.asList(포스트_ID), 블로그_이름))
                 .delete("/manage/posts")
                 .then()
                 .log().all()
@@ -132,9 +132,9 @@ public class PostManageAcceptanceSteps {
                 .isEqualTo(예상_데이터);
     }
 
-    public static ExtractableResponse<Response> 내_관리_글_단일_조회_요청(String 세션_ID, Long 포스트_ID) {
+    public static ExtractableResponse<Response> 내_관리_글_단일_조회_요청(String 세션_ID, String 블로그_이름, Long 포스트_ID) {
         return given(세션_ID)
-                .get("/manage/posts/{id}", 포스트_ID)
+                .get("/manage/posts/{blogName}/{id}", 블로그_이름, 포스트_ID)
                 .then()
                 .log().all()
                 .extract();

--- a/src/test/java/com/mallang/acceptance/post/PostManageAcceptanceTest.java
+++ b/src/test/java/com/mallang/acceptance/post/PostManageAcceptanceTest.java
@@ -9,10 +9,6 @@ import static com.mallang.acceptance.AcceptanceSteps.찾을수_없음;
 import static com.mallang.acceptance.auth.AuthAcceptanceSteps.회원가입과_로그인_후_세션_ID_반환;
 import static com.mallang.acceptance.blog.BlogAcceptanceSteps.블로그_개설;
 import static com.mallang.acceptance.category.CategoryAcceptanceSteps.카테고리_생성;
-import static com.mallang.acceptance.post.PostAcceptanceSteps.보호되지_않음;
-import static com.mallang.acceptance.post.PostAcceptanceSteps.좋아요_안눌림;
-import static com.mallang.acceptance.post.PostAcceptanceSteps.포스트_단일_조회_요청;
-import static com.mallang.acceptance.post.PostAcceptanceSteps.포스트_단일_조회_응답을_검증한다;
 import static com.mallang.acceptance.post.PostManageAcceptanceSteps.공개_포스트_생성_데이터;
 import static com.mallang.acceptance.post.PostManageAcceptanceSteps.내_관리_글_단일_조회_요청;
 import static com.mallang.acceptance.post.PostManageAcceptanceSteps.내_관리_글_단일_조회_응답을_검증한다;
@@ -22,16 +18,14 @@ import static com.mallang.acceptance.post.PostManageAcceptanceSteps.포스트_�
 import static com.mallang.acceptance.post.PostManageAcceptanceSteps.포스트_생성;
 import static com.mallang.acceptance.post.PostManageAcceptanceSteps.포스트_생성_요청;
 import static com.mallang.acceptance.post.PostManageAcceptanceSteps.포스트_수정_요청;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PROTECTED;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PUBLIC;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PROTECTED;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PUBLIC;
 import static java.util.Collections.emptyList;
 
 import com.mallang.acceptance.AcceptanceTest;
 import com.mallang.post.presentation.request.CreatePostRequest;
 import com.mallang.post.presentation.request.UpdatePostRequest;
-import com.mallang.post.query.response.PostDetailResponse;
-import com.mallang.post.query.response.PostDetailResponse.WriterResponse;
 import com.mallang.post.query.response.PostManageDetailResponse;
 import com.mallang.post.query.response.PostManageDetailResponse.CategoryResponse;
 import com.mallang.post.query.response.PostManageDetailResponse.TagResponses;
@@ -95,7 +89,9 @@ class PostManageAcceptanceTest extends AcceptanceTest {
         var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(말랑_블로그_이름));
 
         // when
-        UpdatePostRequest 포스트_업데이트_요청 = new UpdatePostRequest("업데이트 제목",
+        UpdatePostRequest 포스트_업데이트_요청 = new UpdatePostRequest(
+                말랑_블로그_이름,
+                "업데이트 제목",
                 "업데이트 내용",
                 "업데이트 포스트 썸네일 이름",
                 "업데이트 인트로",
@@ -108,37 +104,18 @@ class PostManageAcceptanceTest extends AcceptanceTest {
 
         // then
         응답_상태를_검증한다(응답, 정상_처리);
-        var 조회_결과 = 포스트_단일_조회_요청(말랑_세션_ID, 포스트_ID, null);
-        var 예상_데이터 = new PostDetailResponse(
-                포스트_ID,
-                "업데이트 제목",
-                "업데이트 내용",
-                "업데이트 포스트 썸네일 이름",
-                PRIVATE,
-                보호되지_않음,
-                null,
-                0,
-                좋아요_안눌림,
-                null,
-                new WriterResponse(null, "말랑", "말랑"),
-                new PostDetailResponse.CategoryResponse(Spring_카테고리_ID, "Spring"),
-                new PostDetailResponse.TagResponses(List.of("태그1", "태그2"))
-        );
-        포스트_단일_조회_응답을_검증한다(조회_결과, 예상_데이터);
     }
 
     @Test
     void 포스트를_삭제한다() {
         // given
         var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(말랑_블로그_이름));
-        var 다른_회원_세션_ID = 회원가입과_로그인_후_세션_ID_반환("다른회원");
 
         // when
-        var 응답 = 포스트_삭제_요청(말랑_세션_ID, 포스트_ID);
+        var 응답 = 포스트_삭제_요청(말랑_세션_ID, 포스트_ID, 말랑_블로그_이름);
 
         // then
         응답_상태를_검증한다(응답, 본문_없음);
-        응답_상태를_검증한다(포스트_단일_조회_요청(null, 포스트_ID, null), 찾을수_없음);
     }
 
     @Nested
@@ -163,7 +140,8 @@ class PostManageAcceptanceTest extends AcceptanceTest {
             );
             public_spring_포스트_ID = 포스트_생성(말랑_세션_ID, public_spring_포스트_요청);
 
-            CreatePostRequest protected_jpa_포스트_요청 = new CreatePostRequest(말랑_블로그_이름,
+            CreatePostRequest protected_jpa_포스트_요청 = new CreatePostRequest(
+                    말랑_블로그_이름,
                     "Jpa 입니다",
                     "이번에는 이것 저것들에 대해 알아보아요",
                     "썸넬2",
@@ -175,7 +153,8 @@ class PostManageAcceptanceTest extends AcceptanceTest {
             );
             protected_jpa_포스트_ID = 포스트_생성(말랑_세션_ID, protected_jpa_포스트_요청);
 
-            CreatePostRequest private_front_포스트_요청 = new CreatePostRequest(말랑_블로그_이름,
+            CreatePostRequest private_front_포스트_요청 = new CreatePostRequest(
+                    말랑_블로그_이름,
                     "Front 입니다",
                     "잘 알아보았어요!",
                     null,
@@ -396,7 +375,7 @@ class PostManageAcceptanceTest extends AcceptanceTest {
         @Test
         void 나의_글을_관리용으로_단일_조회한다() {
             // when
-            var 응답 = 내_관리_글_단일_조회_요청(말랑_세션_ID, 포스트_ID);
+            var 응답 = 내_관리_글_단일_조회_요청(말랑_세션_ID, 말랑_블로그_이름, 포스트_ID);
 
             // then
             내_관리_글_단일_조회_응답을_검증한다(응답,
@@ -416,7 +395,7 @@ class PostManageAcceptanceTest extends AcceptanceTest {
         @Test
         void 냐의_글이_아닌_경우_예외() {
             // when
-            var 응답 = 내_관리_글_단일_조회_요청(동훈_세션_ID, 포스트_ID);
+            var 응답 = 내_관리_글_단일_조회_요청(동훈_세션_ID, 말랑_블로그_이름, 포스트_ID);
 
             // then
             응답_상태를_검증한다(응답, 찾을수_없음);

--- a/src/test/java/com/mallang/acceptance/post/PostStarAcceptanceSteps.java
+++ b/src/test/java/com/mallang/acceptance/post/PostStarAcceptanceSteps.java
@@ -12,18 +12,19 @@ import jakarta.annotation.Nullable;
 @SuppressWarnings("NonAsciiCharacters")
 public class PostStarAcceptanceSteps {
 
-    public static ExtractableResponse<Response> 포스트_즐겨찾기_요청(String 세션_ID, Long 포스트_ID, @Nullable String 비밀번호) {
+    public static ExtractableResponse<Response> 포스트_즐겨찾기_요청(String 세션_ID, Long 포스트_ID, String 블로그_이름,
+                                                            @Nullable String 비밀번호) {
         return given(세션_ID)
                 .cookie(POST_PASSWORD_COOKIE, 비밀번호)
-                .body(new StarPostRequest(포스트_ID))
+                .body(new StarPostRequest(포스트_ID, 블로그_이름))
                 .post("/post-stars")
                 .then().log().all()
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 포스트_즐겨찾기_취소_요청(String 세션_ID, Long 포스트_ID) {
+    public static ExtractableResponse<Response> 포스트_즐겨찾기_취소_요청(String 세션_ID, Long 포스트_ID, String 블로그_이름) {
         return given(세션_ID)
-                .body(new CancelPostStarRequest(포스트_ID))
+                .body(new CancelPostStarRequest(포스트_ID, 블로그_이름))
                 .delete("/post-stars")
                 .then().log().all()
                 .extract();

--- a/src/test/java/com/mallang/acceptance/post/PostStarAcceptanceTest.java
+++ b/src/test/java/com/mallang/acceptance/post/PostStarAcceptanceTest.java
@@ -19,9 +19,9 @@ import static com.mallang.acceptance.post.PostManageAcceptanceSteps.포스트_�
 import static com.mallang.acceptance.post.PostStarAcceptanceSteps.특정_회원의_즐겨찾기_포스트_목록_조회_요청;
 import static com.mallang.acceptance.post.PostStarAcceptanceSteps.포스트_즐겨찾기_요청;
 import static com.mallang.acceptance.post.PostStarAcceptanceSteps.포스트_즐겨찾기_취소_요청;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PROTECTED;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PUBLIC;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PROTECTED;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PUBLIC;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -60,6 +60,7 @@ class PostStarAcceptanceTest extends AcceptanceTest {
         동훈_세션_ID = 회원가입과_로그인_후_세션_ID_반환("동훈");
         동훈_ID = 내_정보_조회_요청(동훈_세션_ID).as(MemberResponse.class).id();
         공개_포스트를_보호로_바꾸는_요청 = new UpdatePostRequest(
+                블로그_이름,
                 "보호로 변경",
                 "공개글에서 보호됨",
                 null,
@@ -70,6 +71,7 @@ class PostStarAcceptanceTest extends AcceptanceTest {
                 emptyList()
         );
         공개_포스트를_비공개로_바꾸는_요청 = new UpdatePostRequest(
+                블로그_이름,
                 "보호로 변경",
                 "공개글에서 비공개됨",
                 null,
@@ -90,7 +92,7 @@ class PostStarAcceptanceTest extends AcceptanceTest {
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(블로그_이름));
 
             // when
-            var 응답 = 포스트_즐겨찾기_요청(없음(), 포스트_ID, null);
+            var 응답 = 포스트_즐겨찾기_요청(없음(), 포스트_ID, 블로그_이름, null);
 
             // then
             응답_상태를_검증한다(응답, 인증되지_않음);
@@ -101,7 +103,7 @@ class PostStarAcceptanceTest extends AcceptanceTest {
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(블로그_이름));
 
             // when
-            var 응답 = 포스트_즐겨찾기_요청(동훈_세션_ID, 포스트_ID, null);
+            var 응답 = 포스트_즐겨찾기_요청(동훈_세션_ID, 포스트_ID, 블로그_이름, null);
 
             // then
             응답_상태를_검증한다(응답, 생성됨);
@@ -111,10 +113,10 @@ class PostStarAcceptanceTest extends AcceptanceTest {
         void 이미_즐겨찾기를_누른_포스트에는_중복해서_즐겨찾기를_누를_수_없다() {
             // given
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(블로그_이름));
-            포스트_즐겨찾기_요청(말랑_세션_ID, 포스트_ID, null);
+            포스트_즐겨찾기_요청(말랑_세션_ID, 포스트_ID, 블로그_이름, null);
 
             // when
-            var 응답 = 포스트_즐겨찾기_요청(말랑_세션_ID, 포스트_ID, null);
+            var 응답 = 포스트_즐겨찾기_요청(말랑_세션_ID, 포스트_ID, 블로그_이름, null);
 
             // then
             응답_상태를_검증한다(응답, 중복됨);
@@ -132,7 +134,7 @@ class PostStarAcceptanceTest extends AcceptanceTest {
                     var 포스트_ID = 포스트_생성(말랑_세션_ID, 보호_포스트_생성_데이터(블로그_이름));
 
                     // when
-                    var 응답 = 포스트_즐겨찾기_요청(말랑_세션_ID, 포스트_ID, null);
+                    var 응답 = 포스트_즐겨찾기_요청(말랑_세션_ID, 포스트_ID, 블로그_이름, null);
 
                     // then
                     응답_상태를_검증한다(응답, 생성됨);
@@ -148,7 +150,7 @@ class PostStarAcceptanceTest extends AcceptanceTest {
                     var 포스트_ID = 포스트_생성(말랑_세션_ID, 보호_포스트_생성_데이터(블로그_이름));
 
                     // when
-                    var 응답 = 포스트_즐겨찾기_요청(동훈_세션_ID, 포스트_ID, null);
+                    var 응답 = 포스트_즐겨찾기_요청(동훈_세션_ID, 포스트_ID, 블로그_이름, null);
 
                     // then
                     응답_상태를_검증한다(응답, 권한_없음);
@@ -160,7 +162,7 @@ class PostStarAcceptanceTest extends AcceptanceTest {
                     var 포스트_ID = 포스트_생성(말랑_세션_ID, 보호_포스트_생성_데이터(블로그_이름));
 
                     // when
-                    var 응답 = 포스트_즐겨찾기_요청(동훈_세션_ID, 포스트_ID, "1234");
+                    var 응답 = 포스트_즐겨찾기_요청(동훈_세션_ID, 포스트_ID, 블로그_이름, "1234");
 
                     // then
                     응답_상태를_검증한다(응답, 생성됨);
@@ -177,7 +179,7 @@ class PostStarAcceptanceTest extends AcceptanceTest {
                 var 포스트_ID = 포스트_생성(말랑_세션_ID, 비공개_포스트_생성_데이터(블로그_이름));
 
                 // when
-                var 응답 = 포스트_즐겨찾기_요청(말랑_세션_ID, 포스트_ID, null);
+                var 응답 = 포스트_즐겨찾기_요청(말랑_세션_ID, 포스트_ID, 블로그_이름, null);
 
                 // then
                 응답_상태를_검증한다(응답, 생성됨);
@@ -189,7 +191,7 @@ class PostStarAcceptanceTest extends AcceptanceTest {
                 var 포스트_ID = 포스트_생성(말랑_세션_ID, 비공개_포스트_생성_데이터(블로그_이름));
 
                 // when
-                var 응답 = 포스트_즐겨찾기_요청(동훈_세션_ID, 포스트_ID, null);
+                var 응답 = 포스트_즐겨찾기_요청(동훈_세션_ID, 포스트_ID, 블로그_이름, null);
 
                 // then
                 응답_상태를_검증한다(응답, 권한_없음);
@@ -204,10 +206,10 @@ class PostStarAcceptanceTest extends AcceptanceTest {
         void 즐겨찾기를_취소한다() {
             // given
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(블로그_이름));
-            포스트_즐겨찾기_요청(말랑_세션_ID, 포스트_ID, null);
+            포스트_즐겨찾기_요청(말랑_세션_ID, 포스트_ID, 블로그_이름, null);
 
             // when
-            var 응답 = 포스트_즐겨찾기_취소_요청(말랑_세션_ID, 포스트_ID);
+            var 응답 = 포스트_즐겨찾기_취소_요청(말랑_세션_ID, 포스트_ID, 블로그_이름);
 
             // then
             응답_상태를_검증한다(응답, 본문_없음);
@@ -219,7 +221,7 @@ class PostStarAcceptanceTest extends AcceptanceTest {
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(블로그_이름));
 
             // when
-            var 응답 = 포스트_즐겨찾기_취소_요청(말랑_세션_ID, 포스트_ID);
+            var 응답 = 포스트_즐겨찾기_취소_요청(말랑_세션_ID, 포스트_ID, 블로그_이름);
 
             // then
             응답_상태를_검증한다(응답, 찾을수_없음);
@@ -230,11 +232,11 @@ class PostStarAcceptanceTest extends AcceptanceTest {
             // given
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(블로그_이름));
             var 동훈_세션_ID = 회원가입과_로그인_후_세션_ID_반환("동훈");
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트_ID, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트_ID, 블로그_이름, null);
             포스트_수정_요청(말랑_세션_ID, 포스트_ID, 공개_포스트를_비공개로_바꾸는_요청);
 
             // when
-            var 응답 = 포스트_즐겨찾기_취소_요청(동훈_세션_ID, 포스트_ID);
+            var 응답 = 포스트_즐겨찾기_취소_요청(동훈_세션_ID, 포스트_ID, 블로그_이름);
 
             // then
             응답_상태를_검증한다(응답, 본문_없음);
@@ -245,11 +247,11 @@ class PostStarAcceptanceTest extends AcceptanceTest {
             // given
             var 포스트_ID = 포스트_생성(말랑_세션_ID, 공개_포스트_생성_데이터(블로그_이름));
             var 동훈_세션_ID = 회원가입과_로그인_후_세션_ID_반환("동훈");
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트_ID, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트_ID, 블로그_이름, null);
             포스트_수정_요청(말랑_세션_ID, 포스트_ID, 공개_포스트를_비공개로_바꾸는_요청);
 
             // when
-            var 응답 = 포스트_즐겨찾기_취소_요청(동훈_세션_ID, 포스트_ID);
+            var 응답 = 포스트_즐겨찾기_취소_요청(동훈_세션_ID, 포스트_ID, 블로그_이름);
 
             // then
             응답_상태를_검증한다(응답, 본문_없음);
@@ -306,9 +308,9 @@ class PostStarAcceptanceTest extends AcceptanceTest {
             var 포스트1_ID = 포스트_생성(말랑_세션_ID, 포스트1_데이터);
             var 포스트2_ID = 포스트_생성(말랑_세션_ID, 포스트2_데이터);
             var 포스트3_ID = 포스트_생성(말랑_세션_ID, 포스트3_데이터);
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트1_ID, null);
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트2_ID, null);
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트3_ID, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트1_ID, 블로그_이름, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트2_ID, 블로그_이름, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트3_ID, 블로그_이름, null);
 
             // when
             var 응답 = 특정_회원의_즐겨찾기_포스트_목록_조회_요청(null, 동훈_ID);
@@ -327,9 +329,9 @@ class PostStarAcceptanceTest extends AcceptanceTest {
             var 포스트1_ID = 포스트_생성(말랑_세션_ID, 포스트1_데이터);
             var 포스트2_ID = 포스트_생성(말랑_세션_ID, 포스트2_데이터);
             var 포스트3_ID = 포스트_생성(말랑_세션_ID, 포스트3_데이터);
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트1_ID, null);
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트2_ID, null);
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트3_ID, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트1_ID, 블로그_이름, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트2_ID, 블로그_이름, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트3_ID, 블로그_이름, null);
 
             포스트_수정_요청(말랑_세션_ID, 포스트1_ID, 공개_포스트를_보호로_바꾸는_요청);
 
@@ -350,9 +352,9 @@ class PostStarAcceptanceTest extends AcceptanceTest {
             var 포스트1_ID = 포스트_생성(말랑_세션_ID, 포스트1_데이터);
             var 포스트2_ID = 포스트_생성(말랑_세션_ID, 포스트2_데이터);
             var 포스트3_ID = 포스트_생성(말랑_세션_ID, 포스트3_데이터);
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트1_ID, null);
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트2_ID, null);
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트3_ID, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트1_ID, 블로그_이름, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트2_ID, 블로그_이름, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트3_ID, 블로그_이름, null);
 
             포스트_수정_요청(말랑_세션_ID, 포스트1_ID, 공개_포스트를_보호로_바꾸는_요청);
 
@@ -372,9 +374,9 @@ class PostStarAcceptanceTest extends AcceptanceTest {
             var 포스트1_ID = 포스트_생성(말랑_세션_ID, 포스트1_데이터);
             var 포스트2_ID = 포스트_생성(말랑_세션_ID, 포스트2_데이터);
             var 포스트3_ID = 포스트_생성(말랑_세션_ID, 포스트3_데이터);
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트1_ID, null);
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트2_ID, null);
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트3_ID, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트1_ID, 블로그_이름, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트2_ID, 블로그_이름, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트3_ID, 블로그_이름, null);
 
             포스트_수정_요청(말랑_세션_ID, 포스트1_ID, 공개_포스트를_비공개로_바꾸는_요청);
 
@@ -395,9 +397,9 @@ class PostStarAcceptanceTest extends AcceptanceTest {
             var 포스트1_ID = 포스트_생성(말랑_세션_ID, 포스트1_데이터);
             var 포스트2_ID = 포스트_생성(말랑_세션_ID, 포스트2_데이터);
             var 포스트3_ID = 포스트_생성(말랑_세션_ID, 포스트3_데이터);
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트1_ID, null);
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트2_ID, null);
-            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트3_ID, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트1_ID, 블로그_이름, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트2_ID, 블로그_이름, null);
+            포스트_즐겨찾기_요청(동훈_세션_ID, 포스트3_ID, 블로그_이름, null);
             포스트_수정_요청(말랑_세션_ID, 포스트1_ID, 공개_포스트를_비공개로_바꾸는_요청);
             포스트_수정_요청(말랑_세션_ID, 포스트1_ID, 공개_포스트를_보호로_바꾸는_요청);
 

--- a/src/test/java/com/mallang/blog/application/AboutServiceTest.java
+++ b/src/test/java/com/mallang/blog/application/AboutServiceTest.java
@@ -2,6 +2,7 @@ package com.mallang.blog.application;
 
 import static com.mallang.auth.MemberFixture.동훈;
 import static com.mallang.auth.MemberFixture.말랑;
+import static com.mallang.blog.domain.BlogFixture.mallangBlog;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -31,12 +32,15 @@ class AboutServiceTest extends ServiceTest {
     private Member member;
     private Member other;
     private Blog blog;
+    private WriteAboutCommand writeAboutCommand;
 
     @BeforeEach
     void setUp() {
         member = memberRepository.save(말랑());
         other = memberRepository.save(동훈());
-        blog = blogRepository.save(new Blog("mallang-log", member));
+        blog = blogRepository.save(mallangBlog(member));
+        writeAboutCommand =
+                new WriteAboutCommand(member.getId(), blog.getName(), "안녕하세요");
     }
 
     @Nested
@@ -44,24 +48,20 @@ class AboutServiceTest extends ServiceTest {
 
         @Test
         void 첫_작성이라면_작성된다() {
-            // given
-            WriteAboutCommand command = new WriteAboutCommand(member.getId(), blog.getName(), "안녕하세요");
-
             // when & then
             assertDoesNotThrow(() -> {
-                aboutService.write(command);
+                aboutService.write(writeAboutCommand);
             });
         }
 
         @Test
         void 블로그에_이미_작성된_소개가_있으면_예외() {
             // given
-            WriteAboutCommand command = new WriteAboutCommand(member.getId(), blog.getName(), "안녕하세요");
-            aboutService.write(command);
+            aboutService.write(writeAboutCommand);
 
             // when & then
             assertThatThrownBy(() ->
-                    aboutService.write(command)
+                    aboutService.write(writeAboutCommand)
             ).isInstanceOf(AlreadyExistAboutException.class);
         }
 
@@ -84,8 +84,7 @@ class AboutServiceTest extends ServiceTest {
 
         @BeforeEach
         void setUp() {
-            WriteAboutCommand command = new WriteAboutCommand(member.getId(), blog.getName(), "안녕하세요");
-            aboutId = aboutService.write(command);
+            aboutId = aboutService.write(writeAboutCommand);
         }
 
         @Test
@@ -120,8 +119,7 @@ class AboutServiceTest extends ServiceTest {
 
         @BeforeEach
         void setUp() {
-            WriteAboutCommand command = new WriteAboutCommand(member.getId(), blog.getName(), "안녕하세요");
-            aboutId = aboutService.write(command);
+            aboutId = aboutService.write(writeAboutCommand);
         }
 
         @Test

--- a/src/test/java/com/mallang/blog/application/BlogSubscribeServiceTest.java
+++ b/src/test/java/com/mallang/blog/application/BlogSubscribeServiceTest.java
@@ -37,8 +37,11 @@ class BlogSubscribeServiceTest extends ServiceTest {
 
         @Test
         void 블로그를_구독한다() {
+            // given
+            BlogSubscribeCommand command = new BlogSubscribeCommand(mallangId, otherBlogName);
+
             // when
-            Long subscribeId = blogSubscribeService.subscribe(new BlogSubscribeCommand(mallangId, otherBlogName));
+            Long subscribeId = blogSubscribeService.subscribe(command);
 
             // then
             assertThat(blogSubscribeRepository.findById(subscribeId)).isPresent();
@@ -48,21 +51,23 @@ class BlogSubscribeServiceTest extends ServiceTest {
         void 자신의_블로그를_구독하면_예외() {
             // given
             String mallangBlogName = 블로그_개설(mallangId, "mallang-log");
+            BlogSubscribeCommand command = new BlogSubscribeCommand(mallangId, mallangBlogName);
 
             // when & then
             assertThatThrownBy(() ->
-                    blogSubscribeService.subscribe(new BlogSubscribeCommand(mallangId, mallangBlogName))
+                    blogSubscribeService.subscribe(command)
             ).isInstanceOf(SelfSubscribeException.class);
         }
 
         @Test
         void 이미_구독한_블로그라면_예외() {
             // given
-            blogSubscribeService.subscribe(new BlogSubscribeCommand(mallangId, otherBlogName));
+            BlogSubscribeCommand command = new BlogSubscribeCommand(mallangId, otherBlogName);
+            blogSubscribeService.subscribe(command);
 
             // when & then
             assertThatThrownBy(() ->
-                    blogSubscribeService.subscribe(new BlogSubscribeCommand(mallangId, otherBlogName))
+                    blogSubscribeService.subscribe(command)
             ).isInstanceOf(AlreadySubscribedException.class);
         }
     }
@@ -73,10 +78,12 @@ class BlogSubscribeServiceTest extends ServiceTest {
         @Test
         void 구독한_블로그를_구독_취소한다() {
             // given
-            Long subscribeId = blogSubscribeService.subscribe(new BlogSubscribeCommand(mallangId, otherBlogName));
+            BlogSubscribeCommand subscribeCommand = new BlogSubscribeCommand(mallangId, otherBlogName);
+            Long subscribeId = blogSubscribeService.subscribe(subscribeCommand);
+            BlogUnsubscribeCommand unsubscribeCommand = new BlogUnsubscribeCommand(mallangId, otherBlogName);
 
             // when
-            blogSubscribeService.unsubscribe(new BlogUnsubscribeCommand(mallangId, otherBlogName));
+            blogSubscribeService.unsubscribe(unsubscribeCommand);
 
             // then
             assertThat(blogSubscribeRepository.findById(subscribeId)).isEmpty();
@@ -84,9 +91,12 @@ class BlogSubscribeServiceTest extends ServiceTest {
 
         @Test
         void 구독하지_않은_블로그라면_예외() {
+            // given
+            BlogUnsubscribeCommand command = new BlogUnsubscribeCommand(mallangId, otherBlogName);
+
             // when & then
             assertThatThrownBy(() ->
-                    blogSubscribeService.unsubscribe(new BlogUnsubscribeCommand(mallangId, otherBlogName))
+                    blogSubscribeService.unsubscribe(command)
             ).isInstanceOf(UnsubscribeUnsubscribedBlogException.class);
         }
     }

--- a/src/test/java/com/mallang/blog/domain/AboutTest.java
+++ b/src/test/java/com/mallang/blog/domain/AboutTest.java
@@ -1,6 +1,7 @@
 package com.mallang.blog.domain;
 
-import static com.mallang.auth.MemberFixture.동훈;
+import static com.mallang.auth.MemberFixture.말랑;
+import static com.mallang.blog.domain.BlogFixture.mallangBlog;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -21,11 +22,8 @@ import org.junit.jupiter.api.Test;
 class AboutTest {
 
     private final AboutValidator aboutValidator = mock(AboutValidator.class);
-    private final Member member = 동훈();
-    private final Blog blog = Blog.builder()
-            .name("mallang")
-            .owner(member)
-            .build();
+    private final Member member = 말랑();
+    private final Blog blog = mallangBlog(말랑());
 
     @Nested
     class 작성_시 {

--- a/src/test/java/com/mallang/blog/domain/BlogFixture.java
+++ b/src/test/java/com/mallang/blog/domain/BlogFixture.java
@@ -1,0 +1,22 @@
+package com.mallang.blog.domain;
+
+import com.mallang.auth.domain.Member;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class BlogFixture {
+
+    public static final String MALLANG_BLOG_NAME = "mallang-log";
+
+    public static Blog mallangBlog(Member owner) {
+        return mallangBlog(null, owner);
+    }
+
+    public static Blog mallangBlog(Long id, Member owner) {
+        Blog blog = Blog.builder()
+                .name(MALLANG_BLOG_NAME)
+                .owner(owner)
+                .build();
+        ReflectionTestUtils.setField(blog, "id", id);
+        return blog;
+    }
+}

--- a/src/test/java/com/mallang/blog/domain/BlogTest.java
+++ b/src/test/java/com/mallang/blog/domain/BlogTest.java
@@ -1,6 +1,7 @@
 package com.mallang.blog.domain;
 
-import static com.mallang.auth.MemberFixture.동훈;
+import static com.mallang.auth.MemberFixture.말랑;
+import static com.mallang.blog.domain.BlogFixture.mallangBlog;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,10 +26,7 @@ class BlogTest {
     class 개설_시 {
 
         private final BlogValidator blogValidator = mock(BlogValidator.class);
-        private final Blog blog = Blog.builder()
-                .name("mallang")
-                .owner(동훈())
-                .build();
+        private final Blog blog = mallangBlog(말랑());
 
         @Test
         void 블로그를_생성하려는_회원이_이미_다른_블로그를_가지고_있으면_예외() {

--- a/src/test/java/com/mallang/blog/domain/subscribe/BlogSubscribeTest.java
+++ b/src/test/java/com/mallang/blog/domain/subscribe/BlogSubscribeTest.java
@@ -1,11 +1,12 @@
 package com.mallang.blog.domain.subscribe;
 
+import static com.mallang.auth.MemberFixture.말랑;
+import static com.mallang.auth.MemberFixture.회원;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 
-import com.mallang.auth.MemberFixture;
 import com.mallang.auth.domain.Member;
 import com.mallang.blog.domain.Blog;
 import com.mallang.blog.exception.AlreadySubscribedException;
@@ -22,8 +23,8 @@ import org.junit.jupiter.api.Test;
 class BlogSubscribeTest {
 
     private final BlogSubscribeValidator blogSubscribeValidator = mock(BlogSubscribeValidator.class);
-    private final Member member = MemberFixture.말랑();
-    private final Member other = MemberFixture.회원("other");
+    private final Member member = 말랑();
+    private final Member other = 회원("other");
     private final Blog mallangBlog = new Blog("mallang-log", member);
 
     @Nested

--- a/src/test/java/com/mallang/blog/domain/subscribe/BlogSubscribeValidatorTest.java
+++ b/src/test/java/com/mallang/blog/domain/subscribe/BlogSubscribeValidatorTest.java
@@ -1,12 +1,13 @@
 package com.mallang.blog.domain.subscribe;
 
+import static com.mallang.auth.MemberFixture.말랑;
+import static com.mallang.auth.MemberFixture.회원;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-import com.mallang.auth.MemberFixture;
 import com.mallang.auth.domain.Member;
 import com.mallang.blog.domain.Blog;
 import com.mallang.blog.exception.AlreadySubscribedException;
@@ -24,8 +25,8 @@ class BlogSubscribeValidatorTest {
 
     private final BlogSubscribeRepository blogSubscribeRepository = mock(BlogSubscribeRepository.class);
     private final BlogSubscribeValidator blogSubscribeValidator = new BlogSubscribeValidator(blogSubscribeRepository);
-    private final Member member = MemberFixture.말랑(1L);
-    private final Member other = MemberFixture.회원(2L, "other");
+    private final Member member = 말랑(1L);
+    private final Member other = 회원(2L, "other");
     private final Blog mallangBlog = new Blog("mallang-log", member);
 
     @Nested

--- a/src/test/java/com/mallang/comment/application/CommentEventHandlerTest.java
+++ b/src/test/java/com/mallang/comment/application/CommentEventHandlerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.mallang.comment.domain.Comment;
 import com.mallang.common.ServiceTest;
 import com.mallang.post.domain.PostDeleteEvent;
+import com.mallang.post.domain.PostId;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -24,16 +25,16 @@ class CommentEventHandlerTest extends ServiceTest {
         void 해당_포스트에_달린_댓글들을_모두_제거한다() {
             // given
             Long memberId = 회원을_저장한다("말랑");
-            Long otherMemberId = 회원을_저장한다("ohter");
+            Long otherMemberId = 회원을_저장한다("other");
             String blogName = 블로그_개설(memberId, "mallang-log");
-            Long postId1 = 포스트를_저장한다(memberId, blogName, "제목", "내용");
-            Long postId2 = 포스트를_저장한다(memberId, blogName, "제목2", "내용1");
-            Long post1Comment1 = 댓글을_작성한다(postId1, "댓1", true, otherMemberId);
-            대댓글을_작성한다(postId1, "댓1", true, memberId, post1Comment1);
-            비인증_대댓글을_작성한다(postId1, "댓1", "익1", "1234", post1Comment1);
-            비인증_댓글을_작성한다(postId1, "댓1", "익2", "12345");
+            PostId postId1 = 포스트를_저장한다(memberId, blogName, "제목", "내용");
+            PostId postId2 = 포스트를_저장한다(memberId, blogName, "제목2", "내용1");
+            Long post1Comment1 = 댓글을_작성한다(postId1.getId(), blogName, "댓1", true, otherMemberId);
+            대댓글을_작성한다(postId1.getId(), blogName, "댓1", true, memberId, post1Comment1);
+            비인증_대댓글을_작성한다(postId1.getId(), blogName, "댓1", "익1", "1234", post1Comment1);
+            비인증_댓글을_작성한다(postId1.getId(), blogName, "댓1", "익2", "12345");
 
-            댓글을_작성한다(postId2, "댓1", true, otherMemberId); // no delete
+            댓글을_작성한다(postId2.getId(), blogName, "댓1", true, otherMemberId); // no delete
 
             // when
             publisher.publishEvent(new PostDeleteEvent(postId1));
@@ -41,7 +42,7 @@ class CommentEventHandlerTest extends ServiceTest {
             // then
             List<Comment> all = commentRepository.findAll();
             boolean nonDeleteCommentExist = all.stream()
-                    .anyMatch(it -> (it.getPost().getId().equals(postId1)));
+                    .anyMatch(it -> (it.getPost().getPostId().equals(postId1)));
             assertThat(nonDeleteCommentExist).isFalse();
         }
     }

--- a/src/test/java/com/mallang/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/mallang/comment/application/CommentServiceTest.java
@@ -16,6 +16,7 @@ import com.mallang.comment.exception.CommentDepthConstraintViolationException;
 import com.mallang.comment.exception.NoAuthorityForCommentException;
 import com.mallang.comment.exception.NotFoundCommentException;
 import com.mallang.common.ServiceTest;
+import com.mallang.post.domain.PostId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -32,7 +33,7 @@ class CommentServiceTest extends ServiceTest {
     private Long other1Id;
     private Long other2Id;
     private String blogName;
-    private Long postId;
+    private PostId postId;
 
     @BeforeEach
     void setUp() {
@@ -50,7 +51,8 @@ class CommentServiceTest extends ServiceTest {
         void 로그인한_사용자가_댓글을_작성한다() {
             // given
             WriteAuthCommentCommand command = WriteAuthCommentCommand.builder()
-                    .postId(postId)
+                    .postId(postId.getId())
+                    .blogName(blogName)
                     .content("댓글입니다.")
                     .memberId(other1Id)
                     .secret(false)
@@ -67,7 +69,8 @@ class CommentServiceTest extends ServiceTest {
         void 로그인한_사용자는_비밀_댓글_작성이_가능하다() {
             // given
             WriteAuthCommentCommand command = WriteAuthCommentCommand.builder()
-                    .postId(postId)
+                    .postId(postId.getId())
+                    .blogName(blogName)
                     .content("댓글입니다.")
                     .memberId(other1Id)
                     .secret(true)
@@ -84,7 +87,8 @@ class CommentServiceTest extends ServiceTest {
         void 로그인하지_않은_사용자도_댓글을_달_수_있다() {
             // given
             WriteUnAuthCommentCommand command = WriteUnAuthCommentCommand.builder()
-                    .postId(postId)
+                    .postId(postId.getId())
+                    .blogName(blogName)
                     .content("댓글입니다.")
                     .nickname("비인증1")
                     .password("1234")
@@ -100,9 +104,10 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 대댓글을_작성할_수_있다() {
             // given
-            Long 말랑_댓글_ID = 댓글을_작성한다(postId, "말랑 댓글", false, postWriterId);
+            Long 말랑_댓글_ID = 댓글을_작성한다(postId.getId(), blogName, "말랑 댓글", false, postWriterId);
             WriteUnAuthCommentCommand command = WriteUnAuthCommentCommand.builder()
-                    .postId(postId)
+                    .postId(postId.getId())
+                    .blogName(blogName)
                     .content("대댓글입니다.")
                     .nickname("비인증1")
                     .password("1234")
@@ -125,9 +130,10 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 다른_사람의_댓글에_대댓글을_달_수_있다() {
             // given
-            Long 말랑_댓글_ID = 댓글을_작성한다(postId, "말랑 댓글", true, postWriterId);
+            Long 말랑_댓글_ID = 댓글을_작성한다(postId.getId(), blogName, "말랑 댓글", true, postWriterId);
             WriteAuthCommentCommand command = WriteAuthCommentCommand.builder()
-                    .postId(postId)
+                    .postId(postId.getId())
+                    .blogName(blogName)
                     .content("대댓글입니다.")
                     .memberId(other1Id)
                     .parentCommentId(말랑_댓글_ID)
@@ -149,10 +155,11 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 대댓글에_대해서는_댓글을_달_수_없다() {
             // given
-            Long 말랑_댓글_ID = 댓글을_작성한다(postId, "말랑 댓글", true, postWriterId);
-            Long 대댓글_ID = 대댓글을_작성한다(postId, "대댓글", false, postWriterId, 말랑_댓글_ID);
+            Long 말랑_댓글_ID = 댓글을_작성한다(postId.getId(), blogName, "말랑 댓글", true, postWriterId);
+            Long 대댓글_ID = 대댓글을_작성한다(postId.getId(), blogName, "대댓글", false, postWriterId, 말랑_댓글_ID);
             WriteAuthCommentCommand command = WriteAuthCommentCommand.builder()
-                    .postId(postId)
+                    .postId(postId.getId())
+                    .blogName(blogName)
                     .content("대댓글입니다.")
                     .memberId(postWriterId)
                     .parentCommentId(대댓글_ID)
@@ -173,10 +180,11 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 대댓글을_다는_경우_부모_댓글과_Post_가_다르면_예외() {
             // given
-            Long 포스트2_ID = 포스트를_저장한다(postWriterId, blogName, "포스트2", "내용");
-            Long 말랑_댓글_ID = 댓글을_작성한다(postId, "말랑 댓글", true, postWriterId);
+            PostId 포스트2_ID = 포스트를_저장한다(postWriterId, blogName, "포스트2", "내용");
+            Long 말랑_댓글_ID = 댓글을_작성한다(postId.getId(), blogName, "말랑 댓글", true, postWriterId);
             WriteAuthCommentCommand command = WriteAuthCommentCommand.builder()
-                    .postId(포스트2_ID)
+                    .postId(포스트2_ID.getId())
+                    .blogName(blogName)
                     .content("대댓글입니다.")
                     .memberId(postWriterId)
                     .parentCommentId(말랑_댓글_ID)
@@ -201,7 +209,7 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 댓글이_수정된다() {
             // given
-            Long commentId = 댓글을_작성한다(postId, "댓글", false, other1Id);
+            Long commentId = 댓글을_작성한다(postId.getId(), blogName, "댓글", false, other1Id);
             UpdateAuthCommentCommand command = UpdateAuthCommentCommand.builder()
                     .commentId(commentId)
                     .content("수정")
@@ -220,7 +228,7 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 인증된_사용자의_경우_비공개_여부도_수정할_수_있다() {
             // given
-            Long commentId = 댓글을_작성한다(postId, "댓글", false, other1Id);
+            Long commentId = 댓글을_작성한다(postId.getId(), blogName, "댓글", false, other1Id);
             UpdateAuthCommentCommand command = UpdateAuthCommentCommand.builder()
                     .commentId(commentId)
                     .content("수정")
@@ -240,7 +248,7 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 자신의_댓글이_아닌_경우_예외() {
             // given
-            Long commentId = 댓글을_작성한다(postId, "댓글", false, other1Id);
+            Long commentId = 댓글을_작성한다(postId.getId(), blogName, "댓글", false, other1Id);
             UpdateAuthCommentCommand command = UpdateAuthCommentCommand.builder()
                     .commentId(commentId)
                     .content("수정")
@@ -262,7 +270,7 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 비인증_댓글은_비밀번호가_일치하면_수정할_수_있다() {
             // given
-            Long commentId = 비인증_댓글을_작성한다(postId, "댓글", "mal", "1234");
+            Long commentId = 비인증_댓글을_작성한다(postId.getId(), blogName, "댓글", "mal", "1234");
             UpdateUnAuthCommentCommand command = UpdateUnAuthCommentCommand.builder()
                     .commentId(commentId)
                     .content("수정")
@@ -280,7 +288,7 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 비인증_댓글_수정_시_비밀번호가_틀리면_예외() {
             // given
-            Long commentId = 비인증_댓글을_작성한다(postId, "댓글", "mal", "1234");
+            Long commentId = 비인증_댓글을_작성한다(postId.getId(), blogName, "댓글", "mal", "1234");
             UpdateUnAuthCommentCommand command = UpdateUnAuthCommentCommand.builder()
                     .commentId(commentId)
                     .content("수정")
@@ -300,7 +308,7 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 포스트_주인도_댓글을_수정할수는_없다() {
             // given
-            Long commentId = 댓글을_작성한다(postId, "댓글", false, other1Id);
+            Long commentId = 댓글을_작성한다(postId.getId(), blogName, "댓글", false, other1Id);
             UpdateAuthCommentCommand command = UpdateAuthCommentCommand.builder()
                     .commentId(commentId)
                     .content("수정")
@@ -326,8 +334,8 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 댓글_작성자는_자신의_댓글을_제거할_수_있다() {
             // given
-            Long commentId = 댓글을_작성한다(postId, "댓글", false,
-                    postWriterId);
+            Long commentId = 댓글을_작성한다(
+                    postId.getId(), blogName, "댓글", false, postWriterId);
             DeleteAuthCommentCommand command = DeleteAuthCommentCommand.builder()
                     .commentId(commentId)
                     .memberId(postWriterId)
@@ -345,7 +353,7 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 자신의_댓글이_아닌_경우_예외() {
             // given
-            Long commentId = 댓글을_작성한다(postId, "댓글", false, postWriterId);
+            Long commentId = 댓글을_작성한다(postId.getId(), blogName, "댓글", false, postWriterId);
             DeleteAuthCommentCommand command = DeleteAuthCommentCommand.builder()
                     .commentId(commentId)
                     .memberId(other1Id)
@@ -364,7 +372,7 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 비인증_댓글은_비밀번호가_일치하면_제거할_수_있다() {
             // given
-            Long commentId = 비인증_댓글을_작성한다(postId, "댓글", "mal", "1234");
+            Long commentId = 비인증_댓글을_작성한다(postId.getId(), blogName, "댓글", "mal", "1234");
             DeleteUnAuthCommentCommand command = DeleteUnAuthCommentCommand.builder()
                     .commentId(commentId)
                     .password("1234")
@@ -382,7 +390,7 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 비인증_댓글은_비밀번호가_일치하지_않다면_제거할_수_없다() {
             // given
-            Long commentId = 비인증_댓글을_작성한다(postId, "댓글", "mal", "1234");
+            Long commentId = 비인증_댓글을_작성한다(postId.getId(), blogName, "댓글", "mal", "1234");
             DeleteUnAuthCommentCommand command = DeleteUnAuthCommentCommand.builder()
                     .commentId(commentId)
                     .password("12345")
@@ -401,8 +409,8 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 포스트_작성자는_모든_댓글을_제거할_수_있다() {
             // given
-            Long comment1Id = 댓글을_작성한다(postId, "댓글", false, other1Id);
-            Long comment2Id = 비인증_댓글을_작성한다(postId, "댓글", "mal", "1234");
+            Long comment1Id = 댓글을_작성한다(postId.getId(), blogName, "댓글", false, other1Id);
+            Long comment2Id = 비인증_댓글을_작성한다(postId.getId(), blogName, "댓글", "mal", "1234");
             DeleteAuthCommentCommand command1 = DeleteAuthCommentCommand.builder()
                     .commentId(comment1Id)
                     .memberId(postWriterId)
@@ -428,8 +436,8 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 대댓글_제거_시_부모_댓글과의_관계도_끊어진다() {
             // given
-            Long 말랑_댓글_ID = 댓글을_작성한다(postId, "말랑 댓글", false, postWriterId);
-            Long 대댓글_ID = 비인증_대댓글을_작성한다(postId, "대댓글", "hi", "12", 말랑_댓글_ID);
+            Long 말랑_댓글_ID = 댓글을_작성한다(postId.getId(), blogName, "말랑 댓글", false, postWriterId);
+            Long 대댓글_ID = 비인증_대댓글을_작성한다(postId.getId(), blogName, "대댓글", "hi", "12", 말랑_댓글_ID);
             DeleteUnAuthCommentCommand command = DeleteUnAuthCommentCommand.builder()
                     .commentId(대댓글_ID)
                     .password("12")
@@ -451,8 +459,8 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 대댓글을_삭제하는_경우_부모_댓글이_논리적으로_제거된_상태가_아닌_경우_부모는_변함없다() {
             // given
-            Long 댓글_ID = 비인증_댓글을_작성한다(postId, "말랑 댓글", "hi", "1");
-            Long 대댓글_ID = 비인증_댓글을_작성한다(postId, "대댓글", "hi2", "12");
+            Long 댓글_ID = 비인증_댓글을_작성한다(postId.getId(), blogName, "말랑 댓글", "hi", "1");
+            Long 대댓글_ID = 비인증_댓글을_작성한다(postId.getId(), blogName, "대댓글", "hi2", "12");
             DeleteUnAuthCommentCommand command = DeleteUnAuthCommentCommand.builder()
                     .commentId(대댓글_ID)
                     .password("12")
@@ -474,8 +482,8 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 댓글_제거_시_자식_댓글이_존재한다면_부모와의_연관관계는_유지되며_논리적으로만_제거시킨다() {
             // given
-            Long 댓글_ID = 비인증_댓글을_작성한다(postId, "말랑 댓글", "hi", "1");
-            Long 대댓글_ID = 대댓글을_작성한다(postId, "대댓글", false, postWriterId,
+            Long 댓글_ID = 비인증_댓글을_작성한다(postId.getId(), blogName, "말랑 댓글", "hi", "1");
+            Long 대댓글_ID = 대댓글을_작성한다(postId.getId(), blogName, "대댓글", false, postWriterId,
                     댓글_ID);
             DeleteUnAuthCommentCommand command = DeleteUnAuthCommentCommand.builder()
                     .commentId(댓글_ID)
@@ -499,8 +507,8 @@ class CommentServiceTest extends ServiceTest {
         @Test
         void 대댓글을_삭제하는_경우_부모_댓글이_논리적으로_제거된_상태이며_더이상_존재하는_자식이_없는_경우_부모_댓글도_물리적으로_제거된다() {
             // given
-            Long 댓글_ID = 비인증_댓글을_작성한다(postId, "말랑 댓글", "hi", "12");
-            Long 대댓글_ID = 비인증_대댓글을_작성한다(postId, "대댓글", "hi2", "12", 댓글_ID);
+            Long 댓글_ID = 비인증_댓글을_작성한다(postId.getId(), blogName, "말랑 댓글", "hi", "12");
+            Long 대댓글_ID = 비인증_대댓글을_작성한다(postId.getId(), blogName, "대댓글", "hi2", "12", 댓글_ID);
             unAuthCommentService.delete(new DeleteUnAuthCommentCommand(댓글_ID, "12", null, null));
             DeleteUnAuthCommentCommand command = DeleteUnAuthCommentCommand.builder()
                     .commentId(대댓글_ID)

--- a/src/test/java/com/mallang/comment/domain/AuthCommentTest.java
+++ b/src/test/java/com/mallang/comment/domain/AuthCommentTest.java
@@ -3,8 +3,8 @@ package com.mallang.comment.domain;
 import static com.mallang.auth.MemberFixture.동훈;
 import static com.mallang.auth.MemberFixture.말랑;
 import static com.mallang.auth.MemberFixture.회원;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PROTECTED;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PROTECTED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -15,8 +15,8 @@ import com.mallang.blog.domain.Blog;
 import com.mallang.comment.domain.service.CommentDeleteService;
 import com.mallang.comment.exception.NoAuthorityForCommentException;
 import com.mallang.post.domain.Post;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import com.mallang.post.exception.NoAuthorityAccessPostException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -36,7 +36,6 @@ class AuthCommentTest {
     private final Post post = Post.builder()
             .writer(postWriter)
             .visibilityPolish(new PostVisibilityPolicy(Visibility.PUBLIC, null))
-            .blog(blog)
             .build();
     private final Member member = 말랑(1L);
     private final Member other = 동훈(2L);
@@ -107,7 +106,6 @@ class AuthCommentTest {
             private final Post post = Post.builder()
                     .writer(postWriter)
                     .visibilityPolish(new PostVisibilityPolicy(PROTECTED, "1234"))
-                    .blog(blog)
                     .build();
 
             @Test
@@ -167,7 +165,6 @@ class AuthCommentTest {
             private final Post post = Post.builder()
                     .writer(postWriter)
                     .visibilityPolish(new PostVisibilityPolicy(PRIVATE, null))
-                    .blog(blog)
                     .build();
 
             @Test
@@ -291,7 +288,6 @@ class AuthCommentTest {
             private final Post post = Post.builder()
                     .writer(postWriter)
                     .visibilityPolish(new PostVisibilityPolicy(PROTECTED, "1234"))
-                    .blog(blog)
                     .build();
 
             @Test
@@ -352,7 +348,6 @@ class AuthCommentTest {
             private final Post post = Post.builder()
                     .writer(postWriter)
                     .visibilityPolish(new PostVisibilityPolicy(PRIVATE, null))
-                    .blog(blog)
                     .build();
 
             @Test
@@ -479,7 +474,6 @@ class AuthCommentTest {
             private final Post post = Post.builder()
                     .writer(postWriter)
                     .visibilityPolish(new PostVisibilityPolicy(PROTECTED, "1234"))
-                    .blog(blog)
                     .build();
 
             @Test
@@ -537,7 +531,6 @@ class AuthCommentTest {
             private final Post post = Post.builder()
                     .writer(postWriter)
                     .visibilityPolish(new PostVisibilityPolicy(PRIVATE, null))
-                    .blog(blog)
                     .build();
 
             @Test

--- a/src/test/java/com/mallang/comment/domain/CommentTest.java
+++ b/src/test/java/com/mallang/comment/domain/CommentTest.java
@@ -14,8 +14,8 @@ import com.mallang.blog.domain.Blog;
 import com.mallang.comment.domain.service.CommentDeleteService;
 import com.mallang.comment.exception.CommentDepthConstraintViolationException;
 import com.mallang.post.domain.Post;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -32,7 +32,6 @@ class CommentTest {
     private final Post post = Post.builder()
             .writer(postWriter)
             .visibilityPolish(new PostVisibilityPolicy(Visibility.PUBLIC, null))
-            .blog(blog)
             .build();
     private final Member member = 말랑(1L);
     private final Member other = 동훈(2L);

--- a/src/test/java/com/mallang/comment/domain/UnAuthCommentTest.java
+++ b/src/test/java/com/mallang/comment/domain/UnAuthCommentTest.java
@@ -1,9 +1,9 @@
 package com.mallang.comment.domain;
 
 import static com.mallang.auth.MemberFixture.회원;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PROTECTED;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PUBLIC;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PROTECTED;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PUBLIC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -14,7 +14,7 @@ import com.mallang.blog.domain.Blog;
 import com.mallang.comment.domain.service.CommentDeleteService;
 import com.mallang.comment.exception.NoAuthorityForCommentException;
 import com.mallang.post.domain.Post;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy;
+import com.mallang.post.domain.PostVisibilityPolicy;
 import com.mallang.post.exception.NoAuthorityAccessPostException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -32,7 +32,6 @@ class UnAuthCommentTest {
     private final Post post = Post.builder()
             .visibilityPolish(new PostVisibilityPolicy(PUBLIC, null))
             .writer(postWriter)
-            .blog(blog)
             .build();
 
     @Nested
@@ -80,7 +79,6 @@ class UnAuthCommentTest {
             private final Post post = Post.builder()
                     .writer(postWriter)
                     .visibilityPolish(new PostVisibilityPolicy(PROTECTED, "1234"))
-                    .blog(blog)
                     .build();
 
             @Test
@@ -123,7 +121,6 @@ class UnAuthCommentTest {
             private final Post post = Post.builder()
                     .writer(postWriter)
                     .visibilityPolish(new PostVisibilityPolicy(PRIVATE, null))
-                    .blog(blog)
                     .build();
 
             @Test
@@ -186,7 +183,6 @@ class UnAuthCommentTest {
             private final Post post = Post.builder()
                     .writer(postWriter)
                     .visibilityPolish(new PostVisibilityPolicy(PROTECTED, "1234"))
-                    .blog(blog)
                     .build();
 
             @Test
@@ -230,7 +226,6 @@ class UnAuthCommentTest {
             private final Post post = Post.builder()
                     .writer(postWriter)
                     .visibilityPolish(new PostVisibilityPolicy(PRIVATE, null))
-                    .blog(blog)
                     .build();
 
             @Test
@@ -312,7 +307,6 @@ class UnAuthCommentTest {
             private final Post post = Post.builder()
                     .writer(postWriter)
                     .visibilityPolish(new PostVisibilityPolicy(PROTECTED, "1234"))
-                    .blog(blog)
                     .build();
 
             @Test
@@ -370,7 +364,6 @@ class UnAuthCommentTest {
             private final Post post = Post.builder()
                     .writer(postWriter)
                     .visibilityPolish(new PostVisibilityPolicy(PRIVATE, null))
-                    .blog(blog)
                     .build();
 
             @Test

--- a/src/test/java/com/mallang/comment/domain/service/CommentDeleteServiceTest.java
+++ b/src/test/java/com/mallang/comment/domain/service/CommentDeleteServiceTest.java
@@ -12,8 +12,8 @@ import com.mallang.comment.domain.AuthComment;
 import com.mallang.comment.domain.CommentRepository;
 import com.mallang.comment.domain.UnAuthComment;
 import com.mallang.post.domain.Post;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -36,7 +36,6 @@ class CommentDeleteServiceTest {
     private final Post post = Post.builder()
             .writer(postWriter)
             .visibilityPolish(new PostVisibilityPolicy(Visibility.PUBLIC, null))
-            .blog(blog)
             .build();
     private final Member member = 말랑(1L);
 

--- a/src/test/java/com/mallang/comment/query/CommentQueryServiceTest.java
+++ b/src/test/java/com/mallang/comment/query/CommentQueryServiceTest.java
@@ -6,6 +6,7 @@ import com.mallang.comment.query.response.AuthCommentResponse;
 import com.mallang.comment.query.response.CommentResponse;
 import com.mallang.comment.query.response.UnAuthCommentResponse;
 import com.mallang.common.ServiceTest;
+import com.mallang.post.domain.PostId;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +22,7 @@ class CommentQueryServiceTest extends ServiceTest {
 
     private Long memberId;
     private String blogName;
-    private Long postId;
+    private PostId postId;
 
     @Nested
     class 특정_포스트의_댓글_모두_조회_시 {
@@ -36,12 +37,12 @@ class CommentQueryServiceTest extends ServiceTest {
         @Test
         void 인증되지_않은_요청인_경우_비밀_댓글은_비밀_댓글로_조회된다() {
             // given
-            댓글을_작성한다(postId, "댓글1", false, memberId);
-            댓글을_작성한다(postId, "[비밀] 댓글2", true, memberId);
-            비인증_댓글을_작성한다(postId, "댓글3", "랑말", "1234");
+            댓글을_작성한다(postId.getId(), blogName, "댓글1", false, memberId);
+            댓글을_작성한다(postId.getId(), blogName, "[비밀] 댓글2", true, memberId);
+            비인증_댓글을_작성한다(postId.getId(), blogName, "댓글3", "랑말", "1234");
 
             // when
-            List<CommentResponse> result = commentQueryService.findAllByPostId(postId, null, null);
+            List<CommentResponse> result = commentQueryService.findAllByPost(postId.getId(), blogName, null, null);
 
             // then
             assertThat(result)
@@ -64,14 +65,14 @@ class CommentQueryServiceTest extends ServiceTest {
             // given
             Long dong = 회원을_저장한다("동훈");
             Long hehe = 회원을_저장한다("헤헤");
-            댓글을_작성한다(postId, "동훈 댓글", false, dong);
-            댓글을_작성한다(postId, "헤헤 댓글", false, hehe);
-            댓글을_작성한다(postId, "[비밀] 동훈 댓글2", true, dong); // 제외
-            댓글을_작성한다(postId, "[비밀] 헤헤 댓글2", true, hehe);
-            비인증_댓글을_작성한다(postId, "댓글3", "랑말", "1234");
+            댓글을_작성한다(postId.getId(), blogName, "동훈 댓글", false, dong);
+            댓글을_작성한다(postId.getId(), blogName, "헤헤 댓글", false, hehe);
+            댓글을_작성한다(postId.getId(), blogName, "[비밀] 동훈 댓글2", true, dong); // 제외
+            댓글을_작성한다(postId.getId(), blogName, "[비밀] 헤헤 댓글2", true, hehe);
+            비인증_댓글을_작성한다(postId.getId(), blogName, "댓글3", "랑말", "1234");
 
             // when
-            List<CommentResponse> result = commentQueryService.findAllByPostId(postId, dong, null);
+            List<CommentResponse> result = commentQueryService.findAllByPost(postId.getId(), blogName, dong, null);
 
             // then
             assertThat(result)
@@ -84,14 +85,14 @@ class CommentQueryServiceTest extends ServiceTest {
             // given
             Long dong = 회원을_저장한다("동훈");
             Long hehe = 회원을_저장한다("헤헤");
-            댓글을_작성한다(postId, "동훈 댓글", false, memberId);
-            댓글을_작성한다(postId, "헤헤 댓글", false, hehe);
-            댓글을_작성한다(postId, "[비밀] 동훈 댓글2", true, memberId); // 제외
-            댓글을_작성한다(postId, "[비밀] 헤헤 댓글2", true, hehe);
-            비인증_댓글을_작성한다(postId, "댓글3", "랑말", "1234");
+            댓글을_작성한다(postId.getId(), blogName, "동훈 댓글", false, memberId);
+            댓글을_작성한다(postId.getId(), blogName, "헤헤 댓글", false, hehe);
+            댓글을_작성한다(postId.getId(), blogName, "[비밀] 동훈 댓글2", true, memberId); // 제외
+            댓글을_작성한다(postId.getId(), blogName, "[비밀] 헤헤 댓글2", true, hehe);
+            비인증_댓글을_작성한다(postId.getId(), blogName, "댓글3", "랑말", "1234");
 
             // when
-            List<CommentResponse> result = commentQueryService.findAllByPostId(postId, memberId, null);
+            List<CommentResponse> result = commentQueryService.findAllByPost(postId.getId(), blogName, memberId, null);
 
             // then
             assertThat(result)

--- a/src/test/java/com/mallang/comment/query/CommentResponsePostProcessorTest.java
+++ b/src/test/java/com/mallang/comment/query/CommentResponsePostProcessorTest.java
@@ -2,6 +2,7 @@ package com.mallang.comment.query;
 
 import static com.mallang.auth.MemberFixture.동훈;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -66,7 +67,7 @@ class CommentResponsePostProcessorTest {
             // given
             Post post = mock(Post.class);
             given(post.getWriter()).willReturn(동훈(1L));
-            given(postRepository.getById(1L)).willReturn(post);
+            given(postRepository.getByIdAndBlogName(any(), any())).willReturn(post);
             List<CommentResponse> commentResponses = List.of(
                     AuthCommentResponse.builder()
                             .content("비공개 댓글")
@@ -92,7 +93,8 @@ class CommentResponsePostProcessorTest {
             );
 
             // when
-            List<CommentResponse> commentData = commentDataPostProcessor.processSecret(commentResponses, 1L, 1L);
+            List<CommentResponse> commentData = commentDataPostProcessor.processSecret(commentResponses, 1L, "blog",
+                    1L);
 
             // then
             assertThat(commentData)
@@ -108,7 +110,7 @@ class CommentResponsePostProcessorTest {
             // given
             Post post = mock(Post.class);
             given(post.getWriter()).willReturn(동훈(1L));
-            given(postRepository.getById(1L)).willReturn(post);
+            given(postRepository.getByIdAndBlogName(any(), any())).willReturn(post);
             List<CommentResponse> commentResponses = List.of(
                     AuthCommentResponse.builder()
                             .content("비공개 댓글")
@@ -139,7 +141,8 @@ class CommentResponsePostProcessorTest {
             );
 
             // when
-            List<CommentResponse> commentData = commentDataPostProcessor.processSecret(commentResponses, 1L, null);
+            List<CommentResponse> commentData = commentDataPostProcessor
+                    .processSecret(commentResponses, 1L, "blog", null);
 
             // then
             assertThat(commentData)
@@ -155,7 +158,7 @@ class CommentResponsePostProcessorTest {
             // given
             Post post = mock(Post.class);
             given(post.getWriter()).willReturn(동훈(1L));
-            given(postRepository.getById(1L)).willReturn(post);
+            given(postRepository.getByIdAndBlogName(any(), any())).willReturn(post);
             List<CommentResponse> commentResponses = List.of(
                     AuthCommentResponse.builder()
                             .content("비공개 댓글1")
@@ -186,7 +189,8 @@ class CommentResponsePostProcessorTest {
             );
 
             // when
-            List<CommentResponse> commentData = commentDataPostProcessor.processSecret(commentResponses, 1L, 2L);
+            List<CommentResponse> commentData = commentDataPostProcessor
+                    .processSecret(commentResponses, 1L, "blog", 2L);
 
             // then
             assertThat(commentData)

--- a/src/test/java/com/mallang/comment/query/CommentResponseValidatorTest.java
+++ b/src/test/java/com/mallang/comment/query/CommentResponseValidatorTest.java
@@ -1,9 +1,9 @@
 package com.mallang.comment.query;
 
 import static com.mallang.auth.MemberFixture.말랑;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PROTECTED;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PUBLIC;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PROTECTED;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PUBLIC;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.BDDMockito.given;
@@ -14,7 +14,7 @@ import com.mallang.auth.domain.MemberRepository;
 import com.mallang.blog.domain.Blog;
 import com.mallang.post.domain.Post;
 import com.mallang.post.domain.PostRepository;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy;
+import com.mallang.post.domain.PostVisibilityPolicy;
 import com.mallang.post.exception.NoAuthorityAccessPostException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -39,28 +39,25 @@ class CommentResponseValidatorTest {
     private final Post 공개_포스트 = Post.builder()
             .writer(owner)
             .visibilityPolish(new PostVisibilityPolicy(PUBLIC, null))
-            .blog(blog)
             .build();
     private final Post 보호_포스트 = Post.builder()
             .writer(owner)
-            .blog(blog)
             .visibilityPolish(new PostVisibilityPolicy(PROTECTED, "1234"))
             .build();
     private final Post 비공개_포스트 = Post.builder()
             .writer(owner)
-            .blog(blog)
             .visibilityPolish(new PostVisibilityPolicy(PRIVATE, null))
             .build();
 
     @Test
     void 공개_포스트면_문제없다() {
         // given
-        given(postRepository.getById(1L))
+        given(postRepository.getByIdAndBlogName(1L, blog.getName()))
                 .willReturn(공개_포스트);
 
         // when & then
         assertDoesNotThrow(() -> {
-            commentDataValidator.validateAccessPost(1L, null, null);
+            commentDataValidator.validateAccessPost(1L, blog.getName(), null, null);
         });
     }
 
@@ -68,53 +65,53 @@ class CommentResponseValidatorTest {
     void 포스트_작성자와_조회자가_동일하면_보호든_비공개든_문제없다() {
         // given
         given(memberRepository.getById(10L)).willReturn(owner);
-        given(postRepository.getById(1L))
+        given(postRepository.getByIdAndBlogName(1L, blog.getName()))
                 .willReturn(비공개_포스트);
-        given(postRepository.getById(2L))
+        given(postRepository.getByIdAndBlogName(2L, blog.getName()))
                 .willReturn(보호_포스트);
 
         // when & then
         assertDoesNotThrow(() -> {
-            commentDataValidator.validateAccessPost(1L, owner.getId(), null);
+            commentDataValidator.validateAccessPost(1L, blog.getName(), owner.getId(), null);
         });
         assertDoesNotThrow(() -> {
-            commentDataValidator.validateAccessPost(2L, owner.getId(), null);
+            commentDataValidator.validateAccessPost(2L, blog.getName(), owner.getId(), null);
         });
     }
 
     @Test
     void 보호_포스트인_경우_비밀번호가_일치하면_문제없다() {
         // given
-        given(postRepository.getById(1L))
+        given(postRepository.getByIdAndBlogName(1L, blog.getName()))
                 .willReturn(보호_포스트);
 
         // when & then
         assertDoesNotThrow(() -> {
-            commentDataValidator.validateAccessPost(1L, null, "1234");
+            commentDataValidator.validateAccessPost(1L, blog.getName(), null, "1234");
         });
     }
 
     @Test
     void 포스트_작성자가_아니며_보호_포스트인데_비밀번호가_다르면_예외() {
         // given
-        given(postRepository.getById(1L))
+        given(postRepository.getByIdAndBlogName(1L, blog.getName()))
                 .willReturn(보호_포스트);
 
         // when & then
         assertThatThrownBy(() -> {
-            commentDataValidator.validateAccessPost(1L, 999L, "12345");
+            commentDataValidator.validateAccessPost(1L, blog.getName(), 999L, "12345");
         }).isInstanceOf(NoAuthorityAccessPostException.class);
     }
 
     @Test
     void 포스트_작성자가_아닌데_비공개면_오류() {
         // given
-        given(postRepository.getById(1L))
+        given(postRepository.getByIdAndBlogName(1L, blog.getName()))
                 .willReturn(비공개_포스트);
 
         // when & then
         assertThatThrownBy(() -> {
-            commentDataValidator.validateAccessPost(1L, 999L, null);
+            commentDataValidator.validateAccessPost(1L, blog.getName(), 999L, null);
         }).isInstanceOf(NoAuthorityAccessPostException.class);
     }
 }

--- a/src/test/java/com/mallang/post/application/PostEventHandlerTest.java
+++ b/src/test/java/com/mallang/post/application/PostEventHandlerTest.java
@@ -28,17 +28,17 @@ class PostEventHandlerTest extends ServiceTest {
                     말랑_ID, blogName, "최상위1", null));
             Long categoryId2 = categoryService.create(new CreateCategoryCommand(
                     말랑_ID, blogName, "최상위2", null));
-            Long postId1 = 포스트를_저장한다(말랑_ID, blogName, "제목1", "내용", categoryId1);
-            Long postId2 = 포스트를_저장한다(말랑_ID, blogName, "제목2", "내용", categoryId1);
-            Long postId3 = 포스트를_저장한다(말랑_ID, blogName, "안삭제", "내용", categoryId2);
+            Long postId1 = 포스트를_저장한다(말랑_ID, blogName, "제목1", "내용", categoryId1).getId();
+            Long postId2 = 포스트를_저장한다(말랑_ID, blogName, "제목2", "내용", categoryId1).getId();
+            Long postId3 = 포스트를_저장한다(말랑_ID, blogName, "안삭제", "내용", categoryId2).getId();
 
             // when
             publisher.publishEvent(new CategoryDeletedEvent(categoryId1));
 
             // then
-            assertThat(postRepository.getById((postId1)).getCategory()).isNull();
-            assertThat(postRepository.getById((postId2)).getCategory()).isNull();
-            assertThat(postRepository.getById((postId3)).getCategory()).isNotNull();
+            assertThat(postRepository.getByIdAndBlogName(postId1, blogName).getCategory()).isNull();
+            assertThat(postRepository.getByIdAndBlogName(postId2, blogName).getCategory()).isNull();
+            assertThat(postRepository.getByIdAndBlogName(postId3, blogName).getCategory()).isNotNull();
         }
     }
 }

--- a/src/test/java/com/mallang/post/application/PostLikeEventHandlerTest.java
+++ b/src/test/java/com/mallang/post/application/PostLikeEventHandlerTest.java
@@ -24,7 +24,7 @@ class PostLikeEventHandlerTest extends ServiceTest {
     void setUp() {
         memberId = 회원을_저장한다("말랑");
         blogName = 블로그_개설(memberId, "mallang-log");
-        postId = 포스트를_저장한다(memberId, blogName, "포스트", "내용", "태그1");
+        postId = 포스트를_저장한다(memberId, blogName, "포스트", "내용", "태그1").getId();
     }
 
     @Nested
@@ -32,13 +32,13 @@ class PostLikeEventHandlerTest extends ServiceTest {
 
         @Test
         void 해당_포스트에_눌린_좋아요를_모두_제거한다() {
-            postLikeService.like(new ClickPostLikeCommand(postId, memberId, null));
+            postLikeService.like(new ClickPostLikeCommand(postId, blogName, memberId, null));
 
             // when
-            포스트를_삭제한다(memberId, postId);
+            포스트를_삭제한다(memberId, postId, blogName);
 
             // then
-            assertThat(postLikeRepository.findByPostIdAndMemberId(postId, memberId)).isEmpty();
+            assertThat(postLikeRepository.findByPostIdAndMemberId(postId, blogName, memberId)).isEmpty();
         }
     }
 }

--- a/src/test/java/com/mallang/post/application/PostStarEventHandlerTest.java
+++ b/src/test/java/com/mallang/post/application/PostStarEventHandlerTest.java
@@ -24,7 +24,7 @@ class PostStarEventHandlerTest extends ServiceTest {
     void setUp() {
         memberId = 회원을_저장한다("말랑");
         blogName = 블로그_개설(memberId, "mallang-log");
-        postId = 포스트를_저장한다(memberId, blogName, "포스트", "내용", "태그1");
+        postId = 포스트를_저장한다(memberId, blogName, "포스트", "내용", "태그1").getId();
     }
 
     @Nested
@@ -32,13 +32,13 @@ class PostStarEventHandlerTest extends ServiceTest {
 
         @Test
         void 해당_포스트에_눌린_좋아요를_모두_제거한다() {
-            postStarService.star(new StarPostCommand(postId, memberId, null));
+            postStarService.star(new StarPostCommand(postId, blogName, memberId, null));
 
             // when
-            포스트를_삭제한다(memberId, postId);
+            포스트를_삭제한다(memberId, postId, blogName);
 
             // then
-            assertThat(postStarRepository.findByPostIdAndMemberId(postId, memberId)).isEmpty();
+            assertThat(postStarRepository.findByPostIdAndBlogNameAndMemberId(postId, blogName, memberId)).isEmpty();
         }
     }
 }

--- a/src/test/java/com/mallang/post/application/PostStarServiceTest.java
+++ b/src/test/java/com/mallang/post/application/PostStarServiceTest.java
@@ -1,8 +1,8 @@
 package com.mallang.post.application;
 
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PROTECTED;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PUBLIC;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PROTECTED;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PUBLIC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -11,7 +11,7 @@ import com.mallang.common.ServiceTest;
 import com.mallang.post.application.command.CancelPostStarCommand;
 import com.mallang.post.application.command.StarPostCommand;
 import com.mallang.post.domain.Post;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy;
+import com.mallang.post.domain.PostVisibilityPolicy;
 import com.mallang.post.exception.AlreadyStarPostException;
 import com.mallang.post.exception.NoAuthorityAccessPostException;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,19 +44,22 @@ class PostStarServiceTest extends ServiceTest {
                 blogName,
                 "포스트",
                 "내용",
-                new PostVisibilityPolicy(PUBLIC, null));
+                new PostVisibilityPolicy(PUBLIC, null)
+        ).getId();
         protectedPostId = 포스트를_저장한다(
                 memberId,
                 blogName,
                 "포스트",
                 "내용",
-                new PostVisibilityPolicy(PROTECTED, "1234"));
+                new PostVisibilityPolicy(PROTECTED, "1234")
+        ).getId();
         privatePostId = 포스트를_저장한다(
                 memberId,
                 blogName,
                 "포스트",
                 "내용",
-                new PostVisibilityPolicy(PRIVATE, null));
+                new PostVisibilityPolicy(PRIVATE, null)
+        ).getId();
     }
 
     @Nested
@@ -65,7 +68,7 @@ class PostStarServiceTest extends ServiceTest {
         @Test
         void 로그인해야_즐겨찾기를_누를_수_있다() {
             // given
-            StarPostCommand command = new StarPostCommand(publicPostId, null, null);
+            StarPostCommand command = new StarPostCommand(publicPostId, blogName, null, null);
 
             // when & then
             assertThatThrownBy(() -> {
@@ -76,8 +79,8 @@ class PostStarServiceTest extends ServiceTest {
         @Test
         void 회원이_이미_해당_포스트에_즐겨찾기를_누른_경우_예외() {
             // given
-            postStarService.star(new StarPostCommand(publicPostId, memberId, null));
-            StarPostCommand command = new StarPostCommand(publicPostId, memberId, null);
+            postStarService.star(new StarPostCommand(publicPostId, blogName, memberId, null));
+            StarPostCommand command = new StarPostCommand(publicPostId, blogName, memberId, null);
 
             // when & then
             assertThatThrownBy(() -> {
@@ -88,7 +91,7 @@ class PostStarServiceTest extends ServiceTest {
         @Test
         void 해당_포스트에_즐겨찾기를_누른_적이_없으면_즐겨찾기를_누른다() {
             // when
-            Long starId = postStarService.star(new StarPostCommand(publicPostId, memberId, null));
+            Long starId = postStarService.star(new StarPostCommand(publicPostId, blogName, memberId, null));
 
             // then
             assertThat(starId).isNotNull();
@@ -97,7 +100,7 @@ class PostStarServiceTest extends ServiceTest {
         @Test
         void 글_작성자는_보호된_글에_즐겨찾기를_누를_수_있다() {
             // when
-            Long starId = postStarService.star(new StarPostCommand(protectedPostId, memberId, null));
+            Long starId = postStarService.star(new StarPostCommand(protectedPostId, blogName, memberId, null));
 
             // then
             assertThat(starId).isNotNull();
@@ -106,7 +109,7 @@ class PostStarServiceTest extends ServiceTest {
         @Test
         void 보호된_글의_비밀번호와_입력한_비밀번호가_일치하면_즐겨찾기를_누를_수_있다() {
             // when
-            Long starId = postStarService.star(new StarPostCommand(protectedPostId, otherMemberId, "1234"));
+            Long starId = postStarService.star(new StarPostCommand(protectedPostId, blogName, otherMemberId, "1234"));
 
             // then
             assertThat(starId).isNotNull();
@@ -115,7 +118,7 @@ class PostStarServiceTest extends ServiceTest {
         @Test
         void 보호된_글의_비밀번호와_입력한_비밀번호가_다르면_예외() {
             // given
-            StarPostCommand command = new StarPostCommand(protectedPostId, otherMemberId, "12345");
+            StarPostCommand command = new StarPostCommand(protectedPostId, blogName, otherMemberId, "12345");
 
             // when & then
             assertThatThrownBy(() -> {
@@ -126,8 +129,8 @@ class PostStarServiceTest extends ServiceTest {
         @Test
         void 비공개_글에는_작성자_말고는_즐겨찾기를_누를_수_없다() {
             // given
-            StarPostCommand command1 = new StarPostCommand(privatePostId, memberId, null);
-            StarPostCommand command2 = new StarPostCommand(privatePostId, otherMemberId, null);
+            StarPostCommand command1 = new StarPostCommand(privatePostId, blogName, memberId, null);
+            StarPostCommand command2 = new StarPostCommand(privatePostId, blogName, otherMemberId, null);
 
             // when & then
             assertDoesNotThrow(() -> {
@@ -145,29 +148,29 @@ class PostStarServiceTest extends ServiceTest {
         @Test
         void 즐겨찾기_취소_시_즐겨찾기가_제거된다() {
             // given
-            postStarService.star(new StarPostCommand(publicPostId, memberId, null));
+            postStarService.star(new StarPostCommand(publicPostId, blogName, memberId, null));
 
             // when
-            postStarService.cancel(new CancelPostStarCommand(publicPostId, memberId));
+            postStarService.cancel(new CancelPostStarCommand(memberId, publicPostId, blogName));
 
             // then
-            Post post = postRepository.getById(publicPostId);
+            Post post = postRepository.getByIdAndBlogName(publicPostId, blogName);
             assertThat(post.getLikeCount()).isZero();
         }
 
         @Test
         void 보호글_비공개글_여부에_관계없이_취소할_수_있다() {
             // given
-            postStarService.star(new StarPostCommand(protectedPostId, otherMemberId, "1234"));
-            postStarService.star(new StarPostCommand(publicPostId, otherMemberId, null));
-            포스트_공개여부를_업데이트한다(memberId, publicPostId, PRIVATE, null);
+            postStarService.star(new StarPostCommand(protectedPostId, blogName, otherMemberId, "1234"));
+            postStarService.star(new StarPostCommand(publicPostId, blogName, otherMemberId, null));
+            포스트_공개여부를_업데이트한다(memberId, publicPostId, blogName, PRIVATE, null);
 
             // when & then
             assertDoesNotThrow(() -> {
-                postStarService.cancel(new CancelPostStarCommand(protectedPostId, otherMemberId));
+                postStarService.cancel(new CancelPostStarCommand(otherMemberId, protectedPostId, blogName));
             });
             assertDoesNotThrow(() -> {
-                postStarService.cancel(new CancelPostStarCommand(publicPostId, otherMemberId));
+                postStarService.cancel(new CancelPostStarCommand(otherMemberId, publicPostId, blogName));
             });
         }
     }

--- a/src/test/java/com/mallang/post/domain/PostIdTest.java
+++ b/src/test/java/com/mallang/post/domain/PostIdTest.java
@@ -1,0 +1,31 @@
+package com.mallang.post.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("포스트 ID(PostId) 은(는)")
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class PostIdTest {
+
+    @Test
+    void id와_blogId가_동일하면_같다() {
+        // given
+        PostId postId = new PostId(1L, 2L);
+        PostId same = new PostId(1L, 2L);
+        PostId other1 = new PostId(2L, 2L);
+        PostId other2 = new PostId(1L, 1L);
+
+        // when & then
+        assertThat(postId)
+                .hasSameHashCodeAs(same)
+                .isEqualTo(same)
+                .isNotEqualTo(new Object())
+                .isNotEqualTo(other1)
+                .isNotEqualTo(other2);
+    }
+}

--- a/src/test/java/com/mallang/post/domain/PostOrderInBlogGeneratorTest.java
+++ b/src/test/java/com/mallang/post/domain/PostOrderInBlogGeneratorTest.java
@@ -27,8 +27,11 @@ class PostOrderInBlogGeneratorTest extends ServiceTest {
         포스트를_저장한다(otherId, otherBlogName, "글1", "1");
 
         // when & then
-        assertThat(postOrderInBlogGenerator.generate(blogRepository.getByName(blogName))).isEqualTo(3);
-        assertThat(postOrderInBlogGenerator.generate(blogRepository.getByName(otherBlogName))).isEqualTo(2);
-        assertThat(postOrderInBlogGenerator.generate(blogRepository.getByName(thirdBlogName))).isEqualTo(1);
+        PostId postId = postOrderInBlogGenerator.generate(blogRepository.getByName(blogName).getId());
+        PostId ohterPostId = postOrderInBlogGenerator.generate(blogRepository.getByName(otherBlogName).getId());
+        PostId thirdPostId = postOrderInBlogGenerator.generate(blogRepository.getByName(thirdBlogName).getId());
+        assertThat(postId.getId()).isEqualTo(3);
+        assertThat(ohterPostId.getId()).isEqualTo(2);
+        assertThat(thirdPostId.getId()).isEqualTo(1);
     }
 }

--- a/src/test/java/com/mallang/post/domain/PostTest.java
+++ b/src/test/java/com/mallang/post/domain/PostTest.java
@@ -4,9 +4,9 @@ import static com.mallang.auth.MemberFixture.동훈;
 import static com.mallang.auth.MemberFixture.말랑;
 import static com.mallang.category.CategoryFixture.루트_카테고리;
 import static com.mallang.category.CategoryFixture.하위_카테고리;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PROTECTED;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PUBLIC;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PROTECTED;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PUBLIC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -14,8 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import com.mallang.auth.domain.Member;
 import com.mallang.blog.domain.Blog;
 import com.mallang.category.domain.Category;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import com.mallang.post.exception.DuplicatedTagsInPostException;
 import com.mallang.post.exception.NoAuthorityAccessPostException;
 import com.mallang.post.exception.PostLikeCountNegativeException;
@@ -25,6 +24,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("포스트(Post) 은(는)")
 @SuppressWarnings("NonAsciiCharacters")
@@ -40,13 +40,28 @@ class PostTest {
     private final Category otherMemberCategory = 루트_카테고리("otherMemberCategory", otherMember, otherBlog);
 
     @Test
+    void Id가_같으면_동일하다() {
+        // given
+        Post post1 = Post.builder().title("1").build();
+        Post post2 = Post.builder().title("2").build();
+        ReflectionTestUtils.setField(post1, "postId", new PostId(1L, 2L));
+        ReflectionTestUtils.setField(post2, "postId", new PostId(1L, 2L));
+
+        // when & then
+        assertThat(post1)
+                .isEqualTo(post1)
+                .hasSameHashCodeAs(post2)
+                .isEqualTo(post2)
+                .isNotEqualTo(new Object());
+    }
+
+    @Test
     void 카테고리를_없앨_수_있다() {
         // given
         Post post = Post.builder()
                 .title("제목")
                 .content("내용")
                 .writer(mallang)
-                .blog(blog)
                 .category(springCategory)
                 .build();
 
@@ -67,7 +82,6 @@ class PostTest {
                     .title("제목")
                     .content("내용")
                     .writer(mallang)
-                    .blog(blog)
                     .tags(List.of("tag1", "tag2"))
                     .build();
 
@@ -83,7 +97,6 @@ class PostTest {
                     .title("제목")
                     .content("내용")
                     .writer(mallang)
-                    .blog(blog)
                     .build();
 
             // when & then
@@ -98,7 +111,6 @@ class PostTest {
                             .title("제목")
                             .content("내용")
                             .writer(mallang)
-                            .blog(blog)
                             .tags(List.of("태그1", "태그1"))
                             .build()
             ).isInstanceOf(DuplicatedTagsInPostException.class);
@@ -111,7 +123,6 @@ class PostTest {
                     .title("제목")
                     .content("내용")
                     .writer(mallang)
-                    .blog(blog)
                     .category(jpaCategory)
                     .build();
 
@@ -127,7 +138,6 @@ class PostTest {
                     .content("내용")
                     .postThumbnailImageName("thumbnail")
                     .writer(mallang)
-                    .blog(blog)
                     .build();
 
             // when & then
@@ -141,7 +151,6 @@ class PostTest {
                     .title("제목")
                     .content("내용")
                     .writer(mallang)
-                    .blog(blog)
                     .build();
 
             // when & then
@@ -159,7 +168,6 @@ class PostTest {
                     .title("제목")
                     .content("내용")
                     .writer(mallang)
-                    .blog(blog)
                     .visibilityPolish(new PostVisibilityPolicy(Visibility.PROTECTED, "123"))
                     .tags(List.of("태그1"))
                     .build();
@@ -187,7 +195,6 @@ class PostTest {
                 .title("제목")
                 .content("내용")
                 .writer(mallang)
-                .blog(blog)
                 .build();
 
         @Test
@@ -222,7 +229,6 @@ class PostTest {
                         .content("내용")
                         .writer(mallang)
                         .visibilityPolish(new PostVisibilityPolicy(PUBLIC, null))
-                        .blog(blog)
                         .category(springCategory)
                         .build();
 
@@ -247,7 +253,6 @@ class PostTest {
                     .content("내용")
                     .writer(mallang)
                     .visibilityPolish(new PostVisibilityPolicy(PROTECTED, "1234"))
-                    .blog(blog)
                     .category(springCategory)
                     .build();
 
@@ -284,7 +289,6 @@ class PostTest {
                     .content("내용")
                     .writer(mallang)
                     .visibilityPolish(new PostVisibilityPolicy(PRIVATE, null))
-                    .blog(blog)
                     .category(springCategory)
                     .build();
 
@@ -313,7 +317,6 @@ class PostTest {
                 .title("제목")
                 .content("내용")
                 .writer(mallang)
-                .blog(blog)
                 .build();
 
         // when
@@ -329,7 +332,6 @@ class PostTest {
                 .title("제목")
                 .content("내용")
                 .writer(mallang)
-                .blog(blog)
                 .build();
         post.clickLike();
         post.clickLike();
@@ -349,7 +351,6 @@ class PostTest {
                 .title("제목")
                 .content("내용")
                 .writer(mallang)
-                .blog(blog)
                 .build();
 
         // when

--- a/src/test/java/com/mallang/post/domain/like/PostLikeTest.java
+++ b/src/test/java/com/mallang/post/domain/like/PostLikeTest.java
@@ -2,9 +2,9 @@ package com.mallang.post.domain.like;
 
 import static com.mallang.auth.MemberFixture.말랑;
 import static com.mallang.auth.MemberFixture.회원;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PROTECTED;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PUBLIC;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PROTECTED;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PUBLIC;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -16,7 +16,7 @@ import com.mallang.auth.domain.Member;
 import com.mallang.blog.domain.Blog;
 import com.mallang.post.domain.Post;
 import com.mallang.post.domain.PostIntro;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy;
+import com.mallang.post.domain.PostVisibilityPolicy;
 import com.mallang.post.exception.AlreadyLikedPostException;
 import com.mallang.post.exception.NoAuthorityAccessPostException;
 import org.junit.jupiter.api.DisplayName;
@@ -39,7 +39,6 @@ class PostLikeTest {
             .content("내용")
             .writer(mallang)
             .visibilityPolish(new PostVisibilityPolicy(PUBLIC, null))
-            .blog(blog)
             .build();
 
     @Nested
@@ -98,7 +97,6 @@ class PostLikeTest {
                     .content("내용")
                     .writer(mallang)
                     .visibilityPolish(new PostVisibilityPolicy(PROTECTED, "1234"))
-                    .blog(blog)
                     .build();
 
             @Test
@@ -146,7 +144,6 @@ class PostLikeTest {
                     .content("내용")
                     .writer(mallang)
                     .visibilityPolish(new PostVisibilityPolicy(PRIVATE, null))
-                    .blog(blog)
                     .build();
 
             @Test
@@ -216,7 +213,6 @@ class PostLikeTest {
                     .content("내용")
                     .writer(mallang)
                     .visibilityPolish(new PostVisibilityPolicy(PROTECTED, "1234"))
-                    .blog(blog)
                     .build();
 
             @Test
@@ -270,7 +266,6 @@ class PostLikeTest {
                         .content("내용")
                         .writer(mallang)
                         .visibilityPolish(new PostVisibilityPolicy(PRIVATE, null))
-                        .blog(blog)
                         .build();
                 PostLike postLike = new PostLike(post, mallang);
                 postLike.like(postLikeValidator, null);
@@ -290,7 +285,6 @@ class PostLikeTest {
                         .content("내용")
                         .writer(mallang)
                         .visibilityPolish(new PostVisibilityPolicy(PUBLIC, null))
-                        .blog(blog)
                         .build();
                 PostLike postLike = new PostLike(post, other);
                 postLike.like(postLikeValidator, null);

--- a/src/test/java/com/mallang/post/domain/like/PostLikeValidatorTest.java
+++ b/src/test/java/com/mallang/post/domain/like/PostLikeValidatorTest.java
@@ -28,7 +28,6 @@ class PostLikeValidatorTest {
             .title("제목")
             .content("내용")
             .writer(mallang)
-            .blog(blog)
             .build();
 
     @Test

--- a/src/test/java/com/mallang/post/domain/star/PostStarValidatorTest.java
+++ b/src/test/java/com/mallang/post/domain/star/PostStarValidatorTest.java
@@ -28,7 +28,6 @@ class PostStarValidatorTest {
             .title("제목")
             .content("내용")
             .writer(mallang)
-            .blog(blog)
             .build();
 
     @Test

--- a/src/test/java/com/mallang/post/domain/visibility/PostVisibilityPolicyTest.java
+++ b/src/test/java/com/mallang/post/domain/visibility/PostVisibilityPolicyTest.java
@@ -3,7 +3,8 @@ package com.mallang.post.domain.visibility;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import com.mallang.post.exception.ProtectVisibilityPasswordMustRequired;
 import com.mallang.post.exception.VisibilityPasswordNotRequired;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/mallang/post/query/PostDataProtectorTest.java
+++ b/src/test/java/com/mallang/post/query/PostDataProtectorTest.java
@@ -1,11 +1,11 @@
 package com.mallang.post.query;
 
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PROTECTED;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PUBLIC;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PROTECTED;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PUBLIC;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import com.mallang.post.query.response.PostDetailResponse;
 import com.mallang.post.query.response.PostSearchResponse;
 import com.mallang.post.query.response.PostSearchResponse.WriterResponse;

--- a/src/test/java/com/mallang/post/query/PostDataValidatorTest.java
+++ b/src/test/java/com/mallang/post/query/PostDataValidatorTest.java
@@ -3,7 +3,7 @@ package com.mallang.post.query;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility;
+import com.mallang.post.domain.PostVisibilityPolicy.Visibility;
 import com.mallang.post.query.response.PostDetailResponse;
 import com.mallang.post.query.response.PostDetailResponse.WriterResponse;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/mallang/post/query/PostStarQueryServiceTest.java
+++ b/src/test/java/com/mallang/post/query/PostStarQueryServiceTest.java
@@ -1,13 +1,13 @@
 package com.mallang.post.query;
 
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PROTECTED;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PUBLIC;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PROTECTED;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PUBLIC;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mallang.common.ServiceTest;
 import com.mallang.post.application.command.StarPostCommand;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy;
+import com.mallang.post.domain.PostVisibilityPolicy;
 import com.mallang.post.query.response.StaredPostResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,19 +39,22 @@ class PostStarQueryServiceTest extends ServiceTest {
                 blogName,
                 "포스트1",
                 "내용1",
-                new PostVisibilityPolicy(PUBLIC, null));
+                new PostVisibilityPolicy(PUBLIC, null)
+        ).getId();
         post2Id = 포스트를_저장한다(
                 memberId,
                 blogName,
                 "포스트2",
                 "내용2",
-                new PostVisibilityPolicy(PUBLIC, null));
+                new PostVisibilityPolicy(PUBLIC, null)
+        ).getId();
         post3Id = 포스트를_저장한다(
                 memberId,
                 blogName,
                 "포스트3",
                 "내용3",
-                new PostVisibilityPolicy(PUBLIC, null));
+                new PostVisibilityPolicy(PUBLIC, null)
+        ).getId();
     }
 
     @Nested
@@ -60,9 +63,9 @@ class PostStarQueryServiceTest extends ServiceTest {
         @Test
         void 누구나_볼_수_있다() {
             // given
-            postStarService.star(new StarPostCommand(post1Id, otherMemberId, null));
-            postStarService.star(new StarPostCommand(post2Id, otherMemberId, null));
-            postStarService.star(new StarPostCommand(post3Id, otherMemberId, null));
+            postStarService.star(new StarPostCommand(post1Id, blogName, otherMemberId, null));
+            postStarService.star(new StarPostCommand(post2Id, blogName, otherMemberId, null));
+            postStarService.star(new StarPostCommand(post3Id, blogName, otherMemberId, null));
 
             // when
             Page<StaredPostResponse> result = postStarQueryService.findAllByMemberId(otherMemberId, null, pageable);
@@ -76,11 +79,11 @@ class PostStarQueryServiceTest extends ServiceTest {
         @Test
         void 보호_글은_보호되어_조회된다() {
             // given
-            postStarService.star(new StarPostCommand(post1Id, otherMemberId, null));
-            postStarService.star(new StarPostCommand(post2Id, otherMemberId, null));
-            postStarService.star(new StarPostCommand(post3Id, otherMemberId, null));
+            postStarService.star(new StarPostCommand(post1Id, blogName, otherMemberId, null));
+            postStarService.star(new StarPostCommand(post2Id, blogName, otherMemberId, null));
+            postStarService.star(new StarPostCommand(post3Id, blogName, otherMemberId, null));
 
-            포스트_공개여부를_업데이트한다(memberId, post1Id, PROTECTED, "1234");
+            포스트_공개여부를_업데이트한다(memberId, post1Id, blogName, PROTECTED, "1234");
 
             // when
             Page<StaredPostResponse> result = postStarQueryService.findAllByMemberId(otherMemberId, otherMemberId,
@@ -95,11 +98,11 @@ class PostStarQueryServiceTest extends ServiceTest {
         @Test
         void 글_작성자가_다른_회원의_즐겨찾기_목록_조회_시_글_작성자의_보호글이_즐겨찾이_되어있다면_볼_수_있다() {
             // given
-            postStarService.star(new StarPostCommand(post1Id, otherMemberId, null));
-            postStarService.star(new StarPostCommand(post2Id, otherMemberId, null));
-            postStarService.star(new StarPostCommand(post3Id, otherMemberId, null));
+            postStarService.star(new StarPostCommand(post1Id, blogName, otherMemberId, null));
+            postStarService.star(new StarPostCommand(post2Id, blogName, otherMemberId, null));
+            postStarService.star(new StarPostCommand(post3Id, blogName, otherMemberId, null));
 
-            포스트_공개여부를_업데이트한다(memberId, post1Id, PROTECTED, "1234");
+            포스트_공개여부를_업데이트한다(memberId, post1Id, blogName, PROTECTED, "1234");
 
             // when
             Page<StaredPostResponse> result = postStarQueryService.findAllByMemberId(otherMemberId, memberId, pageable);
@@ -113,11 +116,11 @@ class PostStarQueryServiceTest extends ServiceTest {
         @Test
         void 비공개_글은_누가_조회하든_조회되지_않는다() {
             // given
-            postStarService.star(new StarPostCommand(post1Id, otherMemberId, null));
-            postStarService.star(new StarPostCommand(post2Id, otherMemberId, null));
-            postStarService.star(new StarPostCommand(post3Id, otherMemberId, null));
+            postStarService.star(new StarPostCommand(post1Id, blogName, otherMemberId, null));
+            postStarService.star(new StarPostCommand(post2Id, blogName, otherMemberId, null));
+            postStarService.star(new StarPostCommand(post3Id, blogName, otherMemberId, null));
 
-            포스트_공개여부를_업데이트한다(memberId, post1Id, PRIVATE, null);
+            포스트_공개여부를_업데이트한다(memberId, post1Id, blogName, PRIVATE, null);
 
             // when
             Page<StaredPostResponse> result = postStarQueryService.findAllByMemberId(otherMemberId, memberId, pageable);

--- a/src/test/java/com/mallang/post/query/dao/PostSearchDaoTest.java
+++ b/src/test/java/com/mallang/post/query/dao/PostSearchDaoTest.java
@@ -1,12 +1,12 @@
 package com.mallang.post.query.dao;
 
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PRIVATE;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PROTECTED;
-import static com.mallang.post.domain.visibility.PostVisibilityPolicy.Visibility.PUBLIC;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PRIVATE;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PROTECTED;
+import static com.mallang.post.domain.PostVisibilityPolicy.Visibility.PUBLIC;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mallang.common.ServiceTest;
-import com.mallang.post.domain.visibility.PostVisibilityPolicy;
+import com.mallang.post.domain.PostVisibilityPolicy;
 import com.mallang.post.query.dao.PostSearchDao.PostSearchCond;
 import com.mallang.post.query.response.PostSearchResponse;
 import java.util.List;
@@ -41,13 +41,13 @@ class PostSearchDaoTest extends ServiceTest {
                 new PostVisibilityPolicy(PRIVATE, null));
 
         포스트를_저장한다(otherId, otherBlogName,
-                "ohter-public", "content",
+                "other-public", "content",
                 new PostVisibilityPolicy(PUBLIC, null));
         포스트를_저장한다(otherId, otherBlogName,
-                "ohter-protected", "content",
+                "other-protected", "content",
                 new PostVisibilityPolicy(PROTECTED, "1234"));
         포스트를_저장한다(otherId, otherBlogName,
-                "ohter-private", "content",
+                "other-private", "content",
                 new PostVisibilityPolicy(PRIVATE, null));
     }
 
@@ -62,7 +62,7 @@ class PostSearchDaoTest extends ServiceTest {
         // then
         assertThat(search)
                 .extracting(PostSearchResponse::title)
-                .containsExactly("ohter-protected", "ohter-public",
+                .containsExactly("other-protected", "other-public",
                         "mallang-private", "mallang-protected", "mallang-public"
                 );
     }


### PR DESCRIPTION
- close #101 
- 블로그 ID를 PK로 포함해야 했기 때문에 식별관계 -> @MapsId 사용